### PR TITLE
Bug/ #21

### DIFF
--- a/.github/workflows/spring-cd.yml
+++ b/.github/workflows/spring-cd.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Copy JAR to EC2
         run: |
-          scp -o StrictHostKeyChecking=no *.jar ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/app/app.jar
+          scp -o StrictHostKeyChecking=no app-jar/*.jar ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/app/app.jar
 
       - name: Restart App with Docker Compose
         run: |

--- a/.github/workflows/spring-cd.yml
+++ b/.github/workflows/spring-cd.yml
@@ -1,4 +1,4 @@
-name: Deploy on PR Merged to develop
+name: CD on PR Merged to develop
 
 on:
   pull_request:
@@ -7,51 +7,33 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v3
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    - name: Cache Gradle packages
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle
+      - name: Grant permission to gradlew
+        run: chmod +x gradlew
 
-    - name: Grant permission to gradlew
-      run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build
 
-    - name: Build with Gradle
-      run: ./gradlew build
+      - name: Upload JAR as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-jar
+          path: build/libs/*.jar
 
-    - name: Run tests
-      run: ./gradlew test
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Upload JAR artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: app-jar
-        path: build/libs/*.jar
-
-  deploy-on-merge:
+  deploy:
     needs: build
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
     runs-on: ubuntu-latest
 
     steps:
@@ -60,18 +42,18 @@ jobs:
         with:
           name: app-jar
 
-      - name: Set up SSH
+      - name: Set up SSH Agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
 
       - name: Copy JAR to EC2
         run: |
-          scp -o StrictHostKeyChecking=no app-jar/*.jar ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/app/app.jar
+          scp -o StrictHostKeyChecking=no app-jar/*.jar ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/ubuntu/app/app.jar
 
       - name: Restart App with Docker Compose
         run: |
           ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
-            cd /home/${{ secrets.EC2_USER }}/app
+            cd /home/ubuntu/app
             docker compose up -d --force-recreate
           EOF

--- a/.github/workflows/spring-cd.yml
+++ b/.github/workflows/spring-cd.yml
@@ -43,22 +43,22 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
+    - name: Upload JAR artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: app-jar
+        path: build/libs/*.jar
+
   deploy-on-merge:
-    if: github.event.pull_request.merged == true  # ✔ merge된 PR일 때만 실행
+    needs: build
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout source code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Download JAR artifact
+        uses: actions/download-artifact@v3
         with:
-          distribution: 'temurin'
-          java-version: 17
-
-      - name: Build with Gradle
-        run: ./gradlew clean build -x test
+          name: app-jar
 
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.9.0
@@ -67,11 +67,11 @@ jobs:
 
       - name: Copy JAR to EC2
         run: |
-          scp -i ${{secrets.EC2_SSH_KEY}} -o StrictHostKeyChecking=no build/libs/*.jar ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/app/app.jar
+          scp -o StrictHostKeyChecking=no *.jar ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/app/app.jar
 
       - name: Restart App with Docker Compose
         run: |
-          ssh -i ${{secrets.EC2_SSH_KEY}} -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+          ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
             cd /home/${{ secrets.EC2_USER }}/app
             docker compose up -d --force-recreate
           EOF


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions 워크플로우의 빌드 및 배포 단계가 분리되어 더욱 간소화되었습니다.
  * 빌드 결과물(JAR 파일)이 아티팩트로 업로드되고, 배포 단계에서 이를 다운로드하여 사용하도록 변경되었습니다.
  * 배포 경로가 고정값(`/home/ubuntu/app`)으로 지정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->