### PR TITLE
ref(#53): 새로운 서버로 변경

### DIFF
--- a/.github/workflows/Spring-develop-CD.yml
+++ b/.github/workflows/Spring-develop-CD.yml
@@ -35,7 +35,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: 빌드된 파일 이름 변경하기
-        run: mv ./build/libs/*SNAPSHOT.jar ./cd.jar
+        run: mv ./build/libs/*SNAPSHOT.jar ./CLUE-CD.jar
 
       - name: SCP로 EC2에 빌드된 파일 전송하기
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CI/CD 배포 파이프라인에서 생성되는 SNAPSHOT JAR의 파일명을 CLUE-CD.jar로 변경하여 아티팩트 명명 규칙을 정비했습니다.
  - 전송 단계에서의 파일 참조와의 일치를 요구하는 변경으로, 불일치 시 배포 실패 가능성이 있습니다. 사용자 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->