### PR TITLE
bug(#46): MediaType 수정

### DIFF
--- a/src/main/java/hello/cluebackend/domain/assignment/api/AssignmentCommandController.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/api/AssignmentCommandController.java
@@ -92,7 +92,7 @@ public class AssignmentCommandController {
 
     String original = assignmentAttachment.getOriginalFileName();
     String contentType = assignmentAttachment.getContentType();
-    MediaType mediaType = (contentType != null) ? MediaType.parseMediaType(contentType) : MediaType.APPLICATION_OCTET_STREAM;
+    MediaType mediaType = (contentType != null) ? MediaType.parseMediaType(contentType) : MediaType.ALL;
 
     return ResponseEntity.ok()
             .contentType(mediaType)

--- a/src/main/java/hello/cluebackend/domain/submission/api/SubmissionCommandController.java
+++ b/src/main/java/hello/cluebackend/domain/submission/api/SubmissionCommandController.java
@@ -67,7 +67,7 @@ public class SubmissionCommandController {
     Resource resource = submissionCommandService.downloadAttachment(submissionAttachment);
     return ResponseEntity.ok()
             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + submissionAttachment.getOriginalFileName() + submissionAttachment.getContentType() + "\"")
-            .contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .contentType(MediaType.ALL)
             .body(resource);
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 파일 첨부 다운로드의 콘텐츠 유형 결정 로직을 조정했습니다. 알 수 없는 타입일 때 기존의 application/octet-stream 대신 */* 로 응답하도록 변경했으며, 명시된 타입은 기존과 동일하게 처리합니다. Content-Disposition 헤더와 응답 본문에는 변화가 없습니다. 과제 및 제출 첨부 다운로드 엔드포인트 모두에 적용되어 일부 클라이언트/브라우저의 다운로드 호환성이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->