### PR TITLE
bug(#46): header 값 요청 변경

### DIFF
--- a/src/main/java/hello/cluebackend/domain/submission/api/SubmissionCommandController.java
+++ b/src/main/java/hello/cluebackend/domain/submission/api/SubmissionCommandController.java
@@ -8,6 +8,7 @@ import hello.cluebackend.global.common.annotation.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @RestController
@@ -65,9 +67,17 @@ public class SubmissionCommandController {
   ) throws IOException {
     SubmissionAttachment submissionAttachment = submissionCommandService.findsubmissionAttachmentByIdOrThrow(submissionAttachmentId);
     Resource resource = submissionCommandService.downloadAttachment(submissionAttachment);
+
+    String original = submissionAttachment.getOriginalFileName();
+    String contentType = submissionAttachment.getContentType();
+    MediaType mediaType = (contentType != null) ? MediaType.parseMediaType(contentType) : MediaType.ALL;
+
     return ResponseEntity.ok()
-            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + submissionAttachment.getOriginalFileName() + submissionAttachment.getContentType() + "\"")
-            .contentType(MediaType.ALL)
+            .contentType(mediaType)
+            .header(HttpHeaders.CONTENT_DISPOSITION, ContentDisposition.attachment()
+                    .filename(original, StandardCharsets.UTF_8)
+                    .build()
+                    .toString())
             .body(resource);
   }
 }


### PR DESCRIPTION
header 공통 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 첨부파일 다운로드 시 콘텐츠 타입을 실제 파일 유형에 맞춰 동적으로 설정하여 브라우저 미리보기/열기 동작을 개선했습니다.
  - 파일 이름을 UTF-8로 안전하게 인코딩해 한글·특수문자 등이 깨지지 않고 올바르게 표시되도록 했습니다.
  - 표준 Content-Disposition 헤더 적용으로 일부 브라우저에서 발생하던 파일명 표시 오류 및 다운로드 호환성 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->