### PR TITLE
fix(#9) : swgger Failed to load remote configuration 이슈 해결

### DIFF
--- a/src/main/java/hello/cluebackend/global/config/SecurityConfig.java
+++ b/src/main/java/hello/cluebackend/global/config/SecurityConfig.java
@@ -114,7 +114,13 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/refresh-token", "/register", "/first-register", "/api/timetable/**", "/test", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/", "/refresh-token", "/register", "/first-register", "/api/timetable/**", "/test",
+                                "/h2-console/**",
+                                "/favicon.ico",
+                                "/error",
+                                "/swagger-ui/**",
+                                "/swagger-resources/**",
+                                "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated());
 
 


### PR DESCRIPTION
# 📌 swagger 'Failed to load remote configuration' 이슈 해결

---

## 📑 개요
swagger 'Failed to load remote configuration' 이슈 해결

---

## ✅ 작업 내용
- "/h2-console/**", "/favicon.ico", "/error", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**" 인가 제외

---

## 🔗 관련 이슈
Close fix/#9

---

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 테스트를 완료했나요?

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 비인증 접근 허용 범위를 확대했습니다. 이제 /h2-console/**, /favicon.ico, /error, /swagger-resources/**, /v3/api-docs/** 경로에 로그인 없이 접근할 수 있습니다. 기존 공개 엔드포인트는 그대로 유지되며, 그 외 요청은 기존과 동일하게 인증이 필요합니다. 이로써 개발용 콘솔과 API 문서 접근 편의성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->