### PR TITLE
Revert "Fix/#8"

### DIFF
--- a/src/main/java/hello/cluebackend/global/config/SecurityConfig.java
+++ b/src/main/java/hello/cluebackend/global/config/SecurityConfig.java
@@ -114,7 +114,8 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/refresh-token", "/register", "/first-register", "/api/timetable/**", "/test", "/swagger-ui/**").permitAll()
+//                        .requestMatchers("/", "/refresh-token", "/register", "/first-register", "/api/timetable/**", "/test", "/api/document/download/{documentId:\\d+}").permitAll()
+                        .requestMatchers("/", "/refresh-token", "/register", "/first-register", "/api/timetable/**", "/test").permitAll()
                         .anyRequest().authenticated());
 
 

--- a/src/main/java/hello/cluebackend/global/config/SwaggerConfig.java
+++ b/src/main/java/hello/cluebackend/global/config/SwaggerConfig.java
@@ -18,7 +18,7 @@ public class SwaggerConfig {
 
     private Info apiInfo() {
         return new Info()
-                .title("Clue Swagger")
+                .title("CodeArena Swagger")
                 .description("CLUE REST API")
                 .version("1.0.0");
     }


### PR DESCRIPTION
# 📌 swagger 'Failed to load remote configuration' 이슈 해결

---

## 📑 개요
swagger 'Failed to load remote configuration' 이슈 해결

---

## ✅ 작업 내용
- "/h2-console/**", "/favicon.ico", "/error", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**" 인가 제외

---

## 🔗 관련 이슈
Close fix/8

---

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 테스트를 완료했나요?

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서화
  - API 문서 제목을 “CodeArena Swagger”로 변경했습니다.
- Chores
  - 인증 없이 접근 가능한 공용 엔드포인트 범위를 정리했습니다.
  - API 문서(UI) 페이지는 이제 인증이 필요합니다.
  - 주요 공개 경로는 서비스 이용에 필요한 최소한으로 유지되며, 기존 핵심 흐름(홈, 등록/갱신, 일부 공개 API 등)은 영향 없이 접근 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->