### PR TITLE
Bug/#66

### DIFF
--- a/src/main/generated/hello/cluebackend/domain/assignment/domain/QAssignment.java
+++ b/src/main/generated/hello/cluebackend/domain/assignment/domain/QAssignment.java
@@ -24,7 +24,7 @@ public class QAssignment extends EntityPathBase<Assignment> {
 
     public final QBaseEntity _super = new QBaseEntity(this);
 
-    public final NumberPath<Long> assignmentId = createNumber("assignmentId", Long.class);
+    public final ComparablePath<java.util.UUID> assignmentId = createComparable("assignmentId", java.util.UUID.class);
 
     public final hello.cluebackend.domain.classroom.domain.QClassRoom classRoom;
 

--- a/src/main/generated/hello/cluebackend/domain/assignment/domain/QAssignmentAttachment.java
+++ b/src/main/generated/hello/cluebackend/domain/assignment/domain/QAssignmentAttachment.java
@@ -26,7 +26,7 @@ public class QAssignmentAttachment extends EntityPathBase<AssignmentAttachment> 
 
     public final QAssignment assignment;
 
-    public final NumberPath<Long> assignmentAttachmentId = createNumber("assignmentAttachmentId", Long.class);
+    public final ComparablePath<java.util.UUID> assignmentAttachmentId = createComparable("assignmentAttachmentId", java.util.UUID.class);
 
     public final StringPath contentType = createString("contentType");
 

--- a/src/main/generated/hello/cluebackend/domain/classroom/domain/QClassRoom.java
+++ b/src/main/generated/hello/cluebackend/domain/classroom/domain/QClassRoom.java
@@ -20,7 +20,7 @@ public class QClassRoom extends EntityPathBase<ClassRoom> {
 
     public static final QClassRoom classRoom = new QClassRoom("classRoom");
 
-    public final NumberPath<Long> classRoomId = createNumber("classRoomId", Long.class);
+    public final ComparablePath<java.util.UUID> classRoomId = createComparable("classRoomId", java.util.UUID.class);
 
     public final ListPath<hello.cluebackend.domain.classroomuser.domain.ClassRoomUser, hello.cluebackend.domain.classroomuser.domain.QClassRoomUser> classRoomUserList = this.<hello.cluebackend.domain.classroomuser.domain.ClassRoomUser, hello.cluebackend.domain.classroomuser.domain.QClassRoomUser>createList("classRoomUserList", hello.cluebackend.domain.classroomuser.domain.ClassRoomUser.class, hello.cluebackend.domain.classroomuser.domain.QClassRoomUser.class, PathInits.DIRECT2);
 

--- a/src/main/generated/hello/cluebackend/domain/classroomuser/domain/QClassRoomUser.java
+++ b/src/main/generated/hello/cluebackend/domain/classroomuser/domain/QClassRoomUser.java
@@ -24,7 +24,7 @@ public class QClassRoomUser extends EntityPathBase<ClassRoomUser> {
 
     public final hello.cluebackend.domain.classroom.domain.QClassRoom classRoom;
 
-    public final NumberPath<Long> classRoomUserId = createNumber("classRoomUserId", Long.class);
+    public final ComparablePath<java.util.UUID> classRoomUserId = createComparable("classRoomUserId", java.util.UUID.class);
 
     public final hello.cluebackend.domain.user.domain.QUserEntity user;
 

--- a/src/main/generated/hello/cluebackend/domain/directory/domain/QDirectory.java
+++ b/src/main/generated/hello/cluebackend/domain/directory/domain/QDirectory.java
@@ -24,7 +24,7 @@ public class QDirectory extends EntityPathBase<Directory> {
 
     public final hello.cluebackend.domain.classroom.domain.QClassRoom classRoom;
 
-    public final NumberPath<Long> directoryId = createNumber("directoryId", Long.class);
+    public final ComparablePath<java.util.UUID> directoryId = createComparable("directoryId", java.util.UUID.class);
 
     public final NumberPath<Integer> directoryOrder = createNumber("directoryOrder", Integer.class);
 

--- a/src/main/generated/hello/cluebackend/domain/document/domain/QDocument.java
+++ b/src/main/generated/hello/cluebackend/domain/document/domain/QDocument.java
@@ -30,7 +30,7 @@ public class QDocument extends EntityPathBase<Document> {
 
     public final hello.cluebackend.domain.directory.domain.QDirectory directory;
 
-    public final NumberPath<Long> documentId = createNumber("documentId", Long.class);
+    public final ComparablePath<java.util.UUID> documentId = createComparable("documentId", java.util.UUID.class);
 
     public final StringPath title = createString("title");
 

--- a/src/main/generated/hello/cluebackend/domain/submission/domain/QSubmission.java
+++ b/src/main/generated/hello/cluebackend/domain/submission/domain/QSubmission.java
@@ -40,7 +40,7 @@ public class QSubmission extends EntityPathBase<Submission> {
     //inherited
     public final StringPath lastModifiedBy = _super.lastModifiedBy;
 
-    public final NumberPath<Long> submissionId = createNumber("submissionId", Long.class);
+    public final ComparablePath<java.util.UUID> submissionId = createComparable("submissionId", java.util.UUID.class);
 
     public final DateTimePath<java.time.LocalDateTime> submittedAt = createDateTime("submittedAt", java.time.LocalDateTime.class);
 

--- a/src/main/generated/hello/cluebackend/domain/submission/domain/QSubmissionAttachment.java
+++ b/src/main/generated/hello/cluebackend/domain/submission/domain/QSubmissionAttachment.java
@@ -30,7 +30,7 @@ public class QSubmissionAttachment extends EntityPathBase<SubmissionAttachment> 
 
     public final QSubmission submission;
 
-    public final NumberPath<Long> SubmissionAttachmentId = createNumber("SubmissionAttachmentId", Long.class);
+    public final ComparablePath<java.util.UUID> SubmissionAttachmentId = createComparable("SubmissionAttachmentId", java.util.UUID.class);
 
     public final EnumPath<fileType> type = createEnum("type", fileType.class);
 

--- a/src/main/generated/hello/cluebackend/domain/user/domain/QUserEntity.java
+++ b/src/main/generated/hello/cluebackend/domain/user/domain/QUserEntity.java
@@ -27,7 +27,7 @@ public class QUserEntity extends EntityPathBase<UserEntity> {
 
     public final EnumPath<Role> role = createEnum("role", Role.class);
 
-    public final NumberPath<Long> userId = createNumber("userId", Long.class);
+    public final ComparablePath<java.util.UUID> userId = createComparable("userId", java.util.UUID.class);
 
     public final StringPath username = createString("username");
 

--- a/src/main/java/hello/cluebackend/domain/assignment/api/AssignmentCommandController.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/api/AssignmentCommandController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/assignments")
@@ -40,12 +41,12 @@ public class AssignmentCommandController {
   // 과제 단일 조회
   @GetMapping("/{assignmentId}")
   public ResponseEntity<AssignmentResponseDto> getAssignment(
-          @CurrentUser Long userId,
-          @PathVariable Long assignmentId
+          @CurrentUser UUID userId,
+          @PathVariable UUID assignmentId
   ) {
     AssignmentResponseDto result = assignmentCommandService.findById(assignmentId);
     Assignment assignment = assignmentCommandService.findByIdOrThrow(assignmentId);
-    Long classroomId = assignment.getClassRoom().getClassRoomId();
+    UUID classroomId = assignment.getClassRoom().getClassRoomId();
     if (!classroomUserService.isUserInClassroom(classroomId, userId)) {
       throw new AccessDeniedException("해당 수업실에 속하지 않은 유저입니다.");
     }
@@ -55,8 +56,8 @@ public class AssignmentCommandController {
   // 교실 과제 전체 조회
   @GetMapping("/{classId}/all")
   public ResponseEntity<List<AssignmentResponseDto>> getAllClassroomAssignment(
-          @CurrentUser Long userId,
-          @PathVariable Long classId
+          @CurrentUser UUID userId,
+          @PathVariable UUID classId
   ) {
     List<AssignmentResponseDto> result = assignmentCommandService.findAllById(userId,classId);
 
@@ -69,14 +70,14 @@ public class AssignmentCommandController {
 
   // 메인 페이지 모든 과제 조회
   @GetMapping("/me")
-  public ResponseEntity<List<GetAllAssignmentDto>> getAllAssignments(@CurrentUser Long userId) {
+  public ResponseEntity<List<GetAllAssignmentDto>> getAllAssignments(@CurrentUser UUID userId) {
     List<GetAllAssignmentDto> result = assignmentCommandService.findAllAssignmentMe(userId);
     return ResponseEntity.ok(result);
   }
 
   // 첨부 파일 혹은 링크 전체 조회 (선생, 학생)
   @GetMapping("/{submissionId}/attachment")
-  public ResponseEntity<List<SubmissionAttachmentDto>> findAllAssignments(@CurrentUser Long userId, @PathVariable Long submissionId) {
+  public ResponseEntity<List<SubmissionAttachmentDto>> findAllAssignments(@CurrentUser UUID userId, @PathVariable UUID submissionId) {
     List<SubmissionAttachmentDto> result = submissionCommandService.findAllAssignment(submissionId);
     return ResponseEntity.ok(result);
   }
@@ -84,8 +85,8 @@ public class AssignmentCommandController {
   // 첨부 파일 다운로드
   @GetMapping("/{assignmentAttachmentId}/download")
   public ResponseEntity<Resource> assignmentAttachmentDownload(
-          @CurrentUser Long userId,
-          @PathVariable Long assignmentAttachmentId
+          @CurrentUser UUID userId,
+          @PathVariable UUID assignmentAttachmentId
   ) throws IOException {
     AssignmentAttachment assignmentAttachment = assignmentCommandService.findAssignmentAttachmentByIdOrderThrow(assignmentAttachmentId);
     Resource resource = assignmentCommandService.downloadAttachment(assignmentAttachment);

--- a/src/main/java/hello/cluebackend/domain/assignment/api/AssignmentQueryController.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/api/AssignmentQueryController.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/assignments")
@@ -27,8 +28,8 @@ public class AssignmentQueryController {
 
   // 과제 생성
   @PostMapping
-  public ResponseEntity<Long> createAssignment(
-          @CurrentUser Long userId,
+  public ResponseEntity<UUID> createAssignment(
+          @CurrentUser UUID userId,
           @Valid @RequestBody CreateAssignmentDto request
   ) {
     Assignment assignment = assignmentQueryService.save(userId, request);
@@ -40,8 +41,8 @@ public class AssignmentQueryController {
   // 과제 삭제
   @DeleteMapping("/{assignmentId}")
   public ResponseEntity<?> deleteAssignment(
-          @CurrentUser Long userId,
-          @PathVariable Long assignmentId){
+          @CurrentUser UUID userId,
+          @PathVariable UUID assignmentId){
     assignmentQueryService.delete(assignmentId);
     return ResponseEntity.ok("과제를 성공적으로 삭제했습니다.");
   }
@@ -49,11 +50,11 @@ public class AssignmentQueryController {
   // 과제 수정
   @PatchMapping("/{assignmentId}")
   public ResponseEntity<?> modifyAssignment(
-          @CurrentUser Long userId,
-          @PathVariable Long assignmentId,
+          @CurrentUser UUID userId,
+          @PathVariable UUID assignmentId,
           @Valid @RequestBody ModifyAssignmentDto assignmentDto
   ) {
-    Long assignment = assignmentQueryService.patchAssignment(assignmentId, assignmentDto);
+    UUID assignment = assignmentQueryService.patchAssignment(assignmentId, assignmentDto);
 
     return ResponseEntity.ok(assignment);
   }
@@ -61,8 +62,8 @@ public class AssignmentQueryController {
   // 첨부 파일 추가
   @PostMapping("/{assignmentId}/file")
   public ResponseEntity<?> uploadAttachments(
-          @CurrentUser Long userId,
-          @PathVariable Long assignmentId,
+          @CurrentUser UUID userId,
+          @PathVariable UUID assignmentId,
           @RequestParam("files") MultipartFile[] files
   ) throws IOException {
 
@@ -76,8 +77,8 @@ public class AssignmentQueryController {
   // 첨부 링크 추가
   @PostMapping("/{assignmentId}/link")
   public ResponseEntity<?> urlAttachments(
-          @CurrentUser Long userId,
-          @PathVariable Long assignmentId,
+          @CurrentUser UUID userId,
+          @PathVariable UUID assignmentId,
           @RequestBody List<AssignmentAttachmentDto> assignmentAttachmentDto
   ){
     assignmentQueryService.uploadUrlAttachment(assignmentId, assignmentAttachmentDto);
@@ -87,8 +88,8 @@ public class AssignmentQueryController {
   // 첨부파일 혹은 링크 삭제
   @DeleteMapping("/attachment/{attachmentId}")
   public ResponseEntity<?> deleteAttachment(
-          @CurrentUser Long userId,
-          @PathVariable Long attachmentId
+          @CurrentUser UUID userId,
+          @PathVariable UUID attachmentId
   ) {
     assignmentQueryService.deleteAttachment(attachmentId);
     return ResponseEntity.ok("과제를 성공적으로 삭제했습니다.");

--- a/src/main/java/hello/cluebackend/domain/assignment/api/dto/request/CreateAssignmentDto.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/api/dto/request/CreateAssignmentDto.java
@@ -6,10 +6,11 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Builder
 public record CreateAssignmentDto (
-        @NotNull @JsonProperty("class_id") Long classId,
+        @NotNull @JsonProperty("class_id") UUID classId,
         @NotNull String title,
         @NotNull String content,
         @NotNull @JsonProperty("start_date") @JsonFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime startDate,

--- a/src/main/java/hello/cluebackend/domain/assignment/api/dto/response/AssignmentResponseDto.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/api/dto/response/AssignmentResponseDto.java
@@ -4,10 +4,11 @@ import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Builder
 public record AssignmentResponseDto(
-        Long assignmentId,
+        UUID assignmentId,
         String title,
         String content,
         LocalDateTime startDate,

--- a/src/main/java/hello/cluebackend/domain/assignment/api/dto/response/GetAllAssignmentDto.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/api/dto/response/GetAllAssignmentDto.java
@@ -5,16 +5,17 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @Builder
 public class GetAllAssignmentDto {
-  private Long assignmentId; // 과제 아이디
+  private UUID assignmentId; // 과제 아이디
   private String title; // 과제 제목
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm") private LocalDateTime startDate; // 과제 시작일
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm") private LocalDateTime endDate; // 마감일
 
-  public GetAllAssignmentDto(Long assignmentId, String title, LocalDateTime startDate, LocalDateTime endDate){
+  public GetAllAssignmentDto(UUID assignmentId, String title, LocalDateTime startDate, LocalDateTime endDate){
     this.assignmentId = assignmentId;
     this.title = title;
     this.startDate = startDate;

--- a/src/main/java/hello/cluebackend/domain/assignment/api/dto/response/SubmissionCheck.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/api/dto/response/SubmissionCheck.java
@@ -4,13 +4,14 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @Builder
 public class SubmissionCheck {
   private String userName;
   private int classNumberGrade;
-  private Long submissionId;
+  private UUID submissionId;
   private boolean isSubmitted;
   private LocalDateTime submittedAt;
 }

--- a/src/main/java/hello/cluebackend/domain/assignment/application/AssignmentCommandService.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/application/AssignmentCommandService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +30,7 @@ public class AssignmentCommandService{
   private final FileService fileService;
 
   // 과제 단일 조회
-  public AssignmentResponseDto findById(Long assignmentId) {
+  public AssignmentResponseDto findById(UUID assignmentId) {
     Assignment a = findByIdOrThrow(assignmentId);
     List<AssignmentAttachment> assignmentAttachments = assignmentAttachmentRepository.findAllByAssignment(a);
 
@@ -55,7 +56,7 @@ public class AssignmentCommandService{
   }
 
   // 과제 전체 조회
-  public List<AssignmentResponseDto> findAllById(Long userId, Long classId) {
+  public List<AssignmentResponseDto> findAllById(UUID userId, UUID classId) {
     ClassRoom classRoom = classRoomService.findById(classId).toEntity();
     List<Assignment> assignments = assignmentRepository.findAllByClassRoom(classRoom);
     return assignments.stream()
@@ -64,18 +65,18 @@ public class AssignmentCommandService{
   }
 
   // 과제 ID를 통한 조회
-  public Assignment findByIdOrThrow(Long assignmentId) {
+  public Assignment findByIdOrThrow(UUID assignmentId) {
     return assignmentRepository.findById(assignmentId)
             .orElseThrow(() -> new EntityNotFoundException("해당 과제를 찾을수 없습니다."));
   }
 
-  public AssignmentAttachment findAssignmentAttachmentByIdOrderThrow(Long attachmentId){
+  public AssignmentAttachment findAssignmentAttachmentByIdOrderThrow(UUID attachmentId){
     return assignmentAttachmentRepository.findById(attachmentId)
             .orElseThrow(() -> new EntityNotFoundException("해당 첨부 파일을 찾을수 없습니다."));
   }
 
   // 사용자가 속한 모든 수업 과제 조회
-  public List<GetAllAssignmentDto> findAllAssignmentMe(Long userId) {
+  public List<GetAllAssignmentDto> findAllAssignmentMe(UUID userId) {
     List<Assignment> assignments = assignmentRepository.getAllByUser(userId);
     return assignments.stream()
             .map(a -> GetAllAssignmentDto.builder()

--- a/src/main/java/hello/cluebackend/domain/assignment/application/AssignmentQueryService.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/application/AssignmentQueryService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -33,7 +34,7 @@ public class AssignmentQueryService{
 
   // 과제 생성
   @Transactional
-  public Assignment save(Long userId, CreateAssignmentDto request) {
+  public Assignment save(UUID userId, CreateAssignmentDto request) {
     UserEntity user = userService.findById(userId).toEntity();
 
     ClassRoom classRoom = classRoomRepository.findById(request.classId())
@@ -54,14 +55,14 @@ public class AssignmentQueryService{
 
   // 과제 삭제
   @Transactional
-  public void delete(Long assignmentId) {
+  public void delete(UUID assignmentId) {
     Assignment assignment = assignmentCommandService.findByIdOrThrow(assignmentId);
     assignmentRepository.delete(assignment);
   }
 
   // 과제 수정
   @Transactional
-  public Long patchAssignment(Long assignmentId, ModifyAssignmentDto dto){
+  public UUID patchAssignment(UUID assignmentId, ModifyAssignmentDto dto){
     Assignment assignment = assignmentCommandService.findByIdOrThrow(assignmentId);
     assignment.patch(dto.getTitle(), dto.getContent(), dto.getStartDate(), dto.getEndDate());
     return assignment.getAssignmentId();
@@ -69,7 +70,7 @@ public class AssignmentQueryService{
 
   // url 업로드
   @Transactional
-  public void uploadUrlAttachment(Long assignmentId, List<AssignmentAttachmentDto> dtos) {
+  public void uploadUrlAttachment(UUID assignmentId, List<AssignmentAttachmentDto> dtos) {
     Assignment assignment = assignmentCommandService.findByIdOrThrow(assignmentId);
 
     List<AssignmentAttachment> result = dtos.stream()
@@ -84,7 +85,7 @@ public class AssignmentQueryService{
   }
 
   // 첨부 파일 추가
-  public void uploadFileAttachment(Long assignmentId, MultipartFile file) {
+  public void uploadFileAttachment(UUID assignmentId, MultipartFile file) {
     Assignment assignment = assignmentCommandService.findByIdOrThrow(assignmentId);
 
     String storedFileName = fileService.storeFile(file);
@@ -102,14 +103,11 @@ public class AssignmentQueryService{
 
   // 첨부 파일 업로드 삭제
   @Transactional
-  public void deleteAttachment(Long attachmentId) {
+  public void deleteAttachment(UUID attachmentId) {
     AssignmentAttachment assignmentAttachment = assignmentCommandService.findAssignmentAttachmentByIdOrderThrow(attachmentId);
     if(assignmentAttachment.getType() == FileType.FILE){
       fileService.deleteFile(assignmentAttachment.getValue());
     }
     assignmentAttachmentRepository.delete(assignmentAttachment);
   }
-
-
-
 }

--- a/src/main/java/hello/cluebackend/domain/assignment/domain/Assignment.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/domain/Assignment.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Entity
-@Table(name = "assignments")
+@Table(name = "assignment")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder

--- a/src/main/java/hello/cluebackend/domain/assignment/domain/Assignment.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/domain/Assignment.java
@@ -7,10 +7,12 @@ import hello.cluebackend.domain.classroom.domain.ClassRoom;
 import hello.cluebackend.domain.user.domain.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Table(name = "assignment")
@@ -19,11 +21,10 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 public class Assignment extends BaseEntity {
-
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "assignment_id")
-  private Long assignmentId;
+  @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "uuid2")
+  @Column(name = "assignment_id", nullable = false, updatable = false)
+  private UUID assignmentId;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "classroom_id")

--- a/src/main/java/hello/cluebackend/domain/assignment/domain/Assignment.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/domain/Assignment.java
@@ -15,14 +15,14 @@ import java.util.List;
 import java.util.UUID;
 
 @Entity
-@Table(name = "assignment")
+@Table(name = "assignments")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
 public class Assignment extends BaseEntity {
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY, generator = "uuid2")
+  @GeneratedValue(strategy = GenerationType.UUID)
   @Column(name = "assignment_id", nullable = false, updatable = false)
   private UUID assignmentId;
 

--- a/src/main/java/hello/cluebackend/domain/assignment/domain/AssignmentAttachment.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/domain/AssignmentAttachment.java
@@ -3,6 +3,8 @@ package hello.cluebackend.domain.assignment.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.UUID;
+
 @Entity
 @Table(name = "assignment_attachment")
 @Getter @Setter
@@ -10,9 +12,10 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AssignmentAttachment extends BaseEntity {
-  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "assignment_attachment_id")
-  private Long assignmentAttachmentId;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "assignment_attachment_id", nullable = false, updatable = false)
+  private UUID assignmentAttachmentId;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name="assignment_id")

--- a/src/main/java/hello/cluebackend/domain/assignment/persistence/AssignmentAttachmentRepository.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/persistence/AssignmentAttachmentRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
-public interface AssignmentAttachmentRepository extends JpaRepository<AssignmentAttachment,Long> {
+public interface AssignmentAttachmentRepository extends JpaRepository<AssignmentAttachment, UUID> {
   List<AssignmentAttachment> findAllByAssignment(Assignment assignment);
 }

--- a/src/main/java/hello/cluebackend/domain/assignment/persistence/AssignmentRepository.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/persistence/AssignmentRepository.java
@@ -8,14 +8,15 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
-public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
+public interface AssignmentRepository extends JpaRepository<Assignment, UUID> {
   @Query("SELECT a FROM Submission s" +
           " join s.assignment a" +
           " where s.user.userId =:userId" +
           " AND s.isSubmitted = false")
-  List<Assignment> getAllByUser(@Param("userId") Long userId);
+  List<Assignment> getAllByUser(@Param("userId") UUID userId);
 
   List<Assignment> findAllByClassRoom(ClassRoom classRoom);
 }

--- a/src/main/java/hello/cluebackend/domain/classroom/domain/ClassRoom.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/domain/ClassRoom.java
@@ -10,6 +10,7 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Table(name="class_room")
@@ -19,11 +20,10 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ClassRoom {
-
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false)
-    private Long classRoomId;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "class_room_id", nullable = false, updatable = false)
+    private UUID classRoomId;
 
     @Column(nullable = false, length = 40)
     private String name;

--- a/src/main/java/hello/cluebackend/domain/classroom/domain/repository/ClassRoomRepository.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/domain/repository/ClassRoomRepository.java
@@ -6,12 +6,13 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
-public interface ClassRoomRepository extends JpaRepository<ClassRoom, Long> {
+public interface ClassRoomRepository extends JpaRepository<ClassRoom, UUID> {
     Boolean existsByCode(String code);
 
     Optional<ClassRoom> findByCode(String code);
 
-  ClassRoom findByClassRoomId(Long classRoomId);
+  ClassRoom findByClassRoomId(UUID classRoomId);
 }

--- a/src/main/java/hello/cluebackend/domain/classroom/presentation/ClassRoomController.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/presentation/ClassRoomController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -28,12 +29,12 @@ public class ClassRoomController {
     @GetMapping
     public ResponseEntity<List<ClassRoomCardDto>> getAllClassRooms(HttpServletRequest request){
         String token = jwtUtil.getToken(request);
-        Long userId = jwtUtil.getUserId(token);
+        UUID userId = jwtUtil.getUserId(token);
         return ResponseEntity.ok(classRoomService.findMyClassRoomById(userId));
     }
 
     @GetMapping("/{classId}/all")
-    public ResponseEntity<?> getAllInfo(HttpServletRequest request, @PathVariable Long classId){
+    public ResponseEntity<?> getAllInfo(HttpServletRequest request, @PathVariable UUID classId){
         String token = jwtUtil.getToken(request);
 //        Long userId = jwtUtil.getUserId(token);
 //        Role role = jwtUtil.getRole(token);
@@ -45,7 +46,7 @@ public class ClassRoomController {
     public ResponseEntity<HashMap<?,?>> createClassRoom(@RequestBody ClassRoomDto classRoomDTO, HttpServletRequest request) {
         String token = jwtUtil.getToken(request);
         Role role = jwtUtil.getRole(token);
-        Long userId = jwtUtil.getUserId(token);
+        UUID userId = jwtUtil.getUserId(token);
         if(role != Role.TEACHER) {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
@@ -61,7 +62,7 @@ public class ClassRoomController {
     @PostMapping("/{code}/members")
     public ResponseEntity<?> joinClassRoom(@PathVariable String code, HttpServletRequest request) {
         String token = jwtUtil.getToken(request);
-        Long userId = jwtUtil.getUserId(token);
+        UUID userId = jwtUtil.getUserId(token);
 
         try {
             classRoomService.joinClassRoom(userId, code);
@@ -73,7 +74,7 @@ public class ClassRoomController {
     }
 
     @GetMapping("/{classId}")
-    public ResponseEntity<ClassRoomDto> findClassRoom(@PathVariable Long classId, HttpServletRequest request) {
+    public ResponseEntity<ClassRoomDto> findClassRoom(@PathVariable UUID classId, HttpServletRequest request) {
         String token = jwtUtil.getToken(request);
         Role role = jwtUtil.getRole(token);
 
@@ -86,7 +87,7 @@ public class ClassRoomController {
     }
 
     @PatchMapping("/{classId}")
-    public ResponseEntity<?> updateClassRoom(@PathVariable Long classId, @RequestBody ClassRoomDto classRoomDTO, HttpServletRequest request) {
+    public ResponseEntity<?> updateClassRoom(@PathVariable UUID classId, @RequestBody ClassRoomDto classRoomDTO, HttpServletRequest request) {
         String token = jwtUtil.getToken(request);
         Role role = jwtUtil.getRole(token);
 

--- a/src/main/java/hello/cluebackend/domain/classroom/presentation/dto/ClassRoomAllInfoDto.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/presentation/dto/ClassRoomAllInfoDto.java
@@ -4,6 +4,7 @@ import hello.cluebackend.domain.directory.presentation.dto.DirectoryAllInfoDto;
 import lombok.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -12,7 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 public class ClassRoomAllInfoDto {
 
-    private Long classRoomId;
+    private UUID classRoomId;
     private String classRoomName;
     private String description;
     private List<DirectoryAllInfoDto> directoryList;

--- a/src/main/java/hello/cluebackend/domain/classroom/presentation/dto/ClassRoomCardDto.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/presentation/dto/ClassRoomCardDto.java
@@ -2,13 +2,15 @@ package hello.cluebackend.domain.classroom.presentation.dto;
 
 import lombok.*;
 
+import java.util.UUID;
+
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ClassRoomCardDto {
-    private Long classRoomId;
+    private UUID classRoomId;
     private String name;
     private String sort;
     private String target;

--- a/src/main/java/hello/cluebackend/domain/classroom/presentation/dto/ClassRoomDto.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/presentation/dto/ClassRoomDto.java
@@ -8,12 +8,13 @@ import lombok.Setter;
 
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @Setter
 @Builder
 public class ClassRoomDto {
-    private Long classRoomId;
+    private UUID classRoomId;
     private String name;
     private String description;
     private String sort;

--- a/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomService.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,7 +37,7 @@ public class ClassRoomService {
         this.userRepository = userRepository;
     }
 
-    public List<ClassRoomCardDto> findMyClassRoomById(Long userId) {
+    public List<ClassRoomCardDto> findMyClassRoomById(UUID userId) {
         List<ClassRoomUser> classRoomUsers = classRoomUserRepository.findByUser_UserId(userId);
         return classRoomUsers.stream()
 //                .filter(cu -> cu.getUser().getRole() == Role.STUDENT)
@@ -46,7 +47,7 @@ public class ClassRoomService {
     }
 
     @Transactional
-    public void createClassRoom(ClassRoomDto classRoomDTO, Long userId) {
+    public void createClassRoom(ClassRoomDto classRoomDTO, UUID userId) {
         classRoomDTO.generateCode();
         ClassRoom classRoom = classRoomDTO.toEntity();
         classRoomRepository.save(classRoom);
@@ -60,7 +61,7 @@ public class ClassRoomService {
         classRoomUserRepository.save(classRoomUser);
     }
 
-    public void joinClassRoom(Long userId, String code) {
+    public void joinClassRoom(UUID userId, String code) {
         ClassRoom findClassRoom = classRoomRepository.findByCode(code).orElseThrow(() -> new IllegalArgumentException("classroom not found"));
         UserEntity findUser = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("user not found"));
         ClassRoomUser classRoomUser = ClassRoomUser.builder()
@@ -70,12 +71,12 @@ public class ClassRoomService {
         classRoomUserRepository.save(classRoomUser);
     }
 
-    public ClassRoomDto findById(Long classRoomId) {
+    public ClassRoomDto findById(UUID classRoomId) {
         ClassRoom findClassRoom = classRoomRepository.findById(classRoomId).orElseThrow(() -> new IllegalArgumentException("해당 수업이 존재하지 않습니다."));
         return findClassRoom.toDTO();
     }
 
-    public void updateClassRoom(Long classId, ClassRoomDto classRoomDTO) {
+    public void updateClassRoom(UUID classId, ClassRoomDto classRoomDTO) {
         ClassRoom findClassRoom =  classRoomRepository.findById(classId).orElseThrow(() -> new IllegalArgumentException("해당 수업이 존재하지 않습니다."));
         findClassRoom.setName(classRoomDTO.getName());
         findClassRoom.setSort(classRoomDTO.getSort());
@@ -85,7 +86,7 @@ public class ClassRoomService {
         classRoomRepository.save(findClassRoom);
     }
 
-    public ClassRoomAllInfoDto getAllInfo(Long classId) {
+    public ClassRoomAllInfoDto getAllInfo(UUID classId) {
         ClassRoom classRoom = classRoomRepository.findById(classId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 수업이 존재하지 않습니다."));
 

--- a/src/main/java/hello/cluebackend/domain/classroomuser/application/ClassroomUserService.java
+++ b/src/main/java/hello/cluebackend/domain/classroomuser/application/ClassroomUserService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +29,7 @@ public class ClassroomUserService {
   }
 
   // 수업실에 해당 유저가 속하는지 확인하는 로직
-  public boolean isUserInClassroom(Long classRoomId, Long userId) {
+  public boolean isUserInClassroom(UUID classRoomId, UUID userId) {
     ClassRoom classRoom = classRoomService.findById(classRoomId).toEntity();
     UserEntity user = userService.findById(userId).toEntity();
 

--- a/src/main/java/hello/cluebackend/domain/classroomuser/domain/ClassRoomUser.java
+++ b/src/main/java/hello/cluebackend/domain/classroomuser/domain/ClassRoomUser.java
@@ -5,6 +5,8 @@ import hello.cluebackend.domain.user.domain.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.UUID;
+
 @Entity
 @Table(name="class_room_user")
 @Getter
@@ -12,11 +14,10 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ClassRoomUser {
-
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(nullable = false)
-    private Long classRoomUserId;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "class_room_user_id", nullable = false, updatable = false)
+    private UUID classRoomUserId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/hello/cluebackend/domain/classroomuser/domain/repository/ClassRoomUserRepository.java
+++ b/src/main/java/hello/cluebackend/domain/classroomuser/domain/repository/ClassRoomUserRepository.java
@@ -9,20 +9,21 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
-public interface ClassRoomUserRepository extends JpaRepository<ClassRoomUser, Long> {
+public interface ClassRoomUserRepository extends JpaRepository<ClassRoomUser, UUID> {
 
-    List<ClassRoomUser> findByUser_UserId(Long userId);
+    List<ClassRoomUser> findByUser_UserId(UUID userId);
 
     @Query("SELECT cu.classRoom FROM ClassRoomUser cu WHERE cu.user.userId = :userId")
-    List<ClassRoom> findClassRoomsByUserId(@Param("userId") Long userId);
+    List<ClassRoom> findClassRoomsByUserId(@Param("userId") UUID userId);
 
     @Query("select cu.user from ClassRoomUser cu where cu.classRoom.classRoomId = :classId")
-    List<UserEntity> findUsersByClassRoomId(@Param("classId") Long classId);
+    List<UserEntity> findUsersByClassRoomId(@Param("classId") UUID classId);
 
     @Query("SELECT cru.user FROM ClassRoomUser cru WHERE cru.classRoom.classRoomId = :classRoomId AND cru.user.role = hello.cluebackend.domain.user.domain.Role.STUDENT")
-    List<UserEntity> findAllStudentsByClassRoomId(Long classRoomId);
+    List<UserEntity> findAllStudentsByClassRoomId(UUID classRoomId);
 
     List<ClassRoomUser> user(UserEntity user);
 

--- a/src/main/java/hello/cluebackend/domain/directory/domain/Directory.java
+++ b/src/main/java/hello/cluebackend/domain/directory/domain/Directory.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Builder
@@ -16,9 +17,9 @@ import java.util.List;
 @Setter
 public class Directory {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="directory_id", nullable = false)
-    private Long directoryId;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name="directory_id", nullable = false, updatable = false)
+    private UUID directoryId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "class_room_id",  nullable = false)

--- a/src/main/java/hello/cluebackend/domain/directory/domain/repository/DirectoryRepository.java
+++ b/src/main/java/hello/cluebackend/domain/directory/domain/repository/DirectoryRepository.java
@@ -4,6 +4,8 @@ import hello.cluebackend.domain.directory.domain.Directory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 @Repository
-public interface DirectoryRepository extends JpaRepository<Directory,Long> {
+public interface DirectoryRepository extends JpaRepository<Directory, UUID> {
 }

--- a/src/main/java/hello/cluebackend/domain/directory/presentation/dto/DirectoryAllInfoDto.java
+++ b/src/main/java/hello/cluebackend/domain/directory/presentation/dto/DirectoryAllInfoDto.java
@@ -4,6 +4,7 @@ import hello.cluebackend.domain.document.presentation.dto.DocumentAllInfoDto;
 import lombok.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -11,7 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DirectoryAllInfoDto {
-    private Long directoryId;
+    private UUID directoryId;
     private String directoryName;
     private int directoryOrder;
     private List<DocumentAllInfoDto> documentList;

--- a/src/main/java/hello/cluebackend/domain/directory/presentation/dto/DirectoryDto.java
+++ b/src/main/java/hello/cluebackend/domain/directory/presentation/dto/DirectoryDto.java
@@ -7,13 +7,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public class DirectoryDto {
 
-    private Long directoryId;
+    private UUID directoryId;
     private ClassRoom classRoom;
     private String name;
     private int directoryOrder;

--- a/src/main/java/hello/cluebackend/domain/directory/presentation/dto/RequestDirectoryDto.java
+++ b/src/main/java/hello/cluebackend/domain/directory/presentation/dto/RequestDirectoryDto.java
@@ -2,10 +2,12 @@ package hello.cluebackend.domain.directory.presentation.dto;
 
 import lombok.Getter;
 
+import java.util.UUID;
+
 @Getter
 public class RequestDirectoryDto {
-    private Long directoryId;
-    private Long classRoomId;
+    private UUID directoryId;
+    private UUID classRoomId;
     private String name;
     private int directoryOrder;
 }

--- a/src/main/java/hello/cluebackend/domain/directory/service/DirectoryService.java
+++ b/src/main/java/hello/cluebackend/domain/directory/service/DirectoryService.java
@@ -7,6 +7,8 @@ import hello.cluebackend.domain.directory.domain.repository.DirectoryRepository;
 import hello.cluebackend.domain.directory.presentation.dto.RequestDirectoryDto;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 public class DirectoryService {
 
@@ -39,7 +41,7 @@ public class DirectoryService {
         directoryRepository.save(directory);
     }
 
-    public void deleteById(Long directoryId) {
+    public void deleteById(UUID directoryId) {
         try {
             directoryRepository.deleteById(directoryId);
         } catch(Exception e) {

--- a/src/main/java/hello/cluebackend/domain/document/domain/Document.java
+++ b/src/main/java/hello/cluebackend/domain/document/domain/Document.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Builder
@@ -17,9 +18,9 @@ import java.time.LocalDateTime;
 public class Document {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="document_id", nullable = false)
-    private Long documentId;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name="document_id", nullable = false, updatable = false)
+    private UUID documentId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "class_room_id",  nullable = false)

--- a/src/main/java/hello/cluebackend/domain/document/domain/repository/DocumentRepository.java
+++ b/src/main/java/hello/cluebackend/domain/document/domain/repository/DocumentRepository.java
@@ -4,6 +4,8 @@ import hello.cluebackend.domain.document.domain.Document;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 @Repository
-public interface DocumentRepository extends JpaRepository<Document,Long> {
+public interface DocumentRepository extends JpaRepository<Document, UUID> {
 }

--- a/src/main/java/hello/cluebackend/domain/document/presentation/DocumentController.java
+++ b/src/main/java/hello/cluebackend/domain/document/presentation/DocumentController.java
@@ -22,6 +22,7 @@ import org.springframework.web.util.UriUtils;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Controller
@@ -42,8 +43,8 @@ public class DocumentController {
     public ResponseEntity<?> uploadDocument(
             @RequestPart("metadata") List<RequestDocumentDto> requestDocumentDto,
             @RequestPart("files")  List<MultipartFile> files,
-            @RequestPart("classRoomId") Long classRoomId,
-            @RequestPart("directoryId") Long directoryId,
+            @RequestPart("classRoomId") UUID classRoomId,
+            @RequestPart("directoryId") UUID directoryId,
             HttpServletRequest request) {
         String token = jwtUtil.getToken(request);
         Role role = jwtUtil.getRole(token);
@@ -66,8 +67,8 @@ public class DocumentController {
     public ResponseEntity<?> updateDocument(
             @RequestPart("metadata") List<RequestDocumentDto> requestDocumentDto,
             @RequestPart("files")  List<MultipartFile> files,
-            @RequestPart("classRoomId") Long classRoomId,
-            @RequestPart("directoryId") Long directoryId,
+            @RequestPart("classRoomId") UUID classRoomId,
+            @RequestPart("directoryId") UUID directoryId,
             HttpServletRequest request) {
 
         String token = jwtUtil.getToken(request);
@@ -105,7 +106,7 @@ public class DocumentController {
     }
 
     @GetMapping("/download/{documentId}")
-    public ResponseEntity<UrlResource> downloadDocument(@PathVariable("documentId") Long documentId) {
+    public ResponseEntity<UrlResource> downloadDocument(@PathVariable("documentId") UUID documentId) {
 
         try {
             DocumentDto documentDto = documentService.findById(documentId);

--- a/src/main/java/hello/cluebackend/domain/document/presentation/dto/DocumentAllInfoDto.java
+++ b/src/main/java/hello/cluebackend/domain/document/presentation/dto/DocumentAllInfoDto.java
@@ -3,6 +3,7 @@ package hello.cluebackend.domain.document.presentation.dto;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DocumentAllInfoDto {
-    private Long documentId;
+    private UUID documentId;
     private String title;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/hello/cluebackend/domain/document/presentation/dto/DocumentDto.java
+++ b/src/main/java/hello/cluebackend/domain/document/presentation/dto/DocumentDto.java
@@ -9,13 +9,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class DocumentDto {
-    private Long documentId;
+    private UUID documentId;
     private ClassRoom classRoom;
     private Directory directory;
     private String title;

--- a/src/main/java/hello/cluebackend/domain/document/presentation/dto/RequestDocumentDto.java
+++ b/src/main/java/hello/cluebackend/domain/document/presentation/dto/RequestDocumentDto.java
@@ -2,6 +2,8 @@ package hello.cluebackend.domain.document.presentation.dto;
 
 import lombok.*;
 
+import java.util.UUID;
+
 @Getter
 @Setter
 @Builder
@@ -9,8 +11,7 @@ import lombok.*;
 @NoArgsConstructor
 @ToString
 public class RequestDocumentDto {
-
-    private Long documentId;
+    private UUID documentId;
     private String title;
     private int type;
 

--- a/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
+++ b/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
@@ -38,7 +38,7 @@ public class DocumentService {
         this.directoryRepository = directoryRepository;
     }
 
-    public void storeFiles(Long classRoomId, Long directoryId, List<RequestDocumentDto> requestDocumentDto, List<MultipartFile> files) {
+    public void storeFiles(UUID classRoomId, UUID directoryId, List<RequestDocumentDto> requestDocumentDto, List<MultipartFile> files) {
         ClassRoom findClassRoom = classRoomRepository.findById(classRoomId).orElseThrow(() -> new IllegalArgumentException("해당 교실을 찾을 수가 없습니다."));
         Directory findDirectory = directoryRepository.findById(directoryId).orElseThrow(() -> new IllegalArgumentException("해당 디렉토를을 찾을 수가 없습니다."));
 
@@ -102,7 +102,7 @@ public class DocumentService {
         return UUID.randomUUID().toString() + "_" + originalFileName;
     }
 
-    public void deleteById(Long documentId) {
+    public void deleteById(UUID documentId) {
         Document findDocument = documentRepository.findById(documentId).orElseThrow(() -> new IllegalArgumentException("해당 수업을 찾지 못했습니다."));
         String fullPath = findDocument.getContent();
 
@@ -124,12 +124,12 @@ public class DocumentService {
 
     }
 
-    public DocumentDto findById(Long documentId) {
+    public DocumentDto findById(UUID documentId) {
         Document findDocument = documentRepository.findById(documentId).orElseThrow(() -> new IllegalArgumentException("해당 수업자료가 존재하지 않습니다."));
         return findDocument.toDto();
     }
 
-    public void updateDocument(Long classRoomId, Long directoryId, List<RequestDocumentDto> requestDocumentDto, List<MultipartFile> files) {
+    public void updateDocument(UUID classRoomId, UUID directoryId, List<RequestDocumentDto> requestDocumentDto, List<MultipartFile> files) {
         System.out.println("directoryId = " + directoryId);
         ClassRoom findClassRoom = classRoomRepository.findById(classRoomId).orElseThrow(() -> new IllegalArgumentException("해당 교실을 찾을 수가 없습니다."));
         Directory findDirectory = directoryRepository.findById(directoryId).orElseThrow(() -> new IllegalArgumentException("해당 디렉토를을 찾을 수가 없습니다."));

--- a/src/main/java/hello/cluebackend/domain/submission/api/SubmissionCommandController.java
+++ b/src/main/java/hello/cluebackend/domain/submission/api/SubmissionCommandController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/submissions")
@@ -31,8 +32,8 @@ public class SubmissionCommandController {
   // 할당된 과제 전체 조회
   @GetMapping("/assignment/{assignmentId}")
   public ResponseEntity<List<SubmissionDto>> findAllSubmission(
-          @CurrentUser Long userId,
-          @PathVariable Long assignmentId
+          @CurrentUser UUID userId,
+          @PathVariable UUID assignmentId
   ) {
     List<SubmissionDto> result = submissionCommandService.findAllByAssignmentId(userId,assignmentId);
     return ResponseEntity.ok(result);
@@ -41,8 +42,8 @@ public class SubmissionCommandController {
   // 할당된 과제 단일 조회
   @GetMapping("/{submissionId}")
   public ResponseEntity<SubmissionDto> findSubmission(
-          @CurrentUser Long userId,
-          @PathVariable Long assignmentId
+          @CurrentUser UUID userId,
+          @PathVariable UUID assignmentId
   ) {
     SubmissionDto result = submissionCommandService.findByAssignmentId(assignmentId);
 
@@ -52,8 +53,8 @@ public class SubmissionCommandController {
   // 전체 학생 과제 제출 여부
   @GetMapping("/{assignmentId}/check")
   public ResponseEntity<List<SubmissionCheck>> checkAssignment(
-          @CurrentUser Long userId,
-          @PathVariable Long assignmentId
+          @CurrentUser UUID userId,
+          @PathVariable UUID assignmentId
   ){
     List<SubmissionCheck> assignmentChecks = submissionCommandService.checkAssignment(userId,assignmentId);
     return ResponseEntity.ok(assignmentChecks);
@@ -62,8 +63,8 @@ public class SubmissionCommandController {
   // 첨부파일 다운로드
   @GetMapping("/{submissionAttachmentId}/download")
   public ResponseEntity<Resource> submissionAttachmentDownload(
-          @CurrentUser Long userId,
-          @PathVariable Long submissionAttachmentId
+          @CurrentUser UUID userId,
+          @PathVariable UUID submissionAttachmentId
   ) throws IOException {
     SubmissionAttachment submissionAttachment = submissionCommandService.findsubmissionAttachmentByIdOrThrow(submissionAttachmentId);
     Resource resource = submissionCommandService.downloadAttachment(submissionAttachment);

--- a/src/main/java/hello/cluebackend/domain/submission/api/SubmissionQueryController.java
+++ b/src/main/java/hello/cluebackend/domain/submission/api/SubmissionQueryController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/submissions")
@@ -23,8 +24,8 @@ public class SubmissionQueryController {
   // 과제 제출 하기
   @PatchMapping("/{submissionId}/submit")
   public ResponseEntity<?> submitSubmission(
-          @CurrentUser Long userId,
-          @PathVariable Long submissionId
+          @CurrentUser UUID userId,
+          @PathVariable UUID submissionId
     ) {
     Submission submission = submissionQueryService.submitSubmission(submissionId);
     return ResponseEntity.ok(submission);
@@ -33,8 +34,8 @@ public class SubmissionQueryController {
   // 과제 제출 취소하기
   @PatchMapping("/{submissionId}/cancel")
   public ResponseEntity<?> cancelSubmission(
-          @CurrentUser Long userId,
-          @PathVariable Long submissionId
+          @CurrentUser UUID userId,
+          @PathVariable UUID submissionId
   ){
     Submission submission = submissionQueryService.cancelSubmission(submissionId);
     return ResponseEntity.ok(submission);
@@ -43,8 +44,8 @@ public class SubmissionQueryController {
 
   @DeleteMapping("/{submissionAttachmentId}")
   public ResponseEntity<?> deleteSubmission(
-          @CurrentUser Long userId,
-          @PathVariable Long submissionAttachmentId
+          @CurrentUser UUID userId,
+          @PathVariable UUID submissionAttachmentId
   ){
     submissionQueryService.deleteSubmissionAttachment(submissionAttachmentId);
     return ResponseEntity.ok("과제 첨부파일이 성공적으로 삭제되었습니다.");
@@ -53,8 +54,8 @@ public class SubmissionQueryController {
   // 과제 제출 첨부 파일 추가
   @PostMapping("/{submissionId}/file")
   public ResponseEntity<SubmissionAttachment> fileUpload(
-          @CurrentUser Long userId,
-          @PathVariable Long submissionId,
+          @CurrentUser UUID userId,
+          @PathVariable UUID submissionId,
           @RequestBody MultipartFile file
   ) throws IOException {
     SubmissionAttachment submissionAttachment = submissionQueryService.fileUpload(submissionId, file);
@@ -64,8 +65,8 @@ public class SubmissionQueryController {
   // 과제 제출 첨부 링크 추가
   @PostMapping("/{submisisonId}/link")
   public ResponseEntity<?> deleteFile(
-          @CurrentUser Long userId,
-          @PathVariable Long submissionId,
+          @CurrentUser UUID userId,
+          @PathVariable UUID submissionId,
           @RequestBody SubmissionAttachmentUrlDto dto
   ) {
     submissionQueryService.linkUpload(submissionId, dto);

--- a/src/main/java/hello/cluebackend/domain/submission/application/SubmissionCommandService.java
+++ b/src/main/java/hello/cluebackend/domain/submission/application/SubmissionCommandService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +30,7 @@ public class SubmissionCommandService {
   private final FileService fileService;
 
   // 과제 제출 여부 확인 API
-  public List<SubmissionCheck> checkAssignment(Long userId, Long assignmentId) {
+  public List<SubmissionCheck> checkAssignment(UUID userId, UUID assignmentId) {
     Assignment assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow(() -> new EntityNotFoundException("해당 과제를 찾을수 없습니다."));
     List<Submission> submissions = submissionRepository.findAllByAssignment(assignment);
@@ -46,7 +47,7 @@ public class SubmissionCommandService {
             .toList();
   }
 
-  public List<SubmissionDto> findAllByAssignmentId(Long userId, Long assignmentId) {
+  public List<SubmissionDto> findAllByAssignmentId(UUID userId, UUID assignmentId) {
     Assignment assignment = assignmentCommandService.findByIdOrThrow(assignmentId);
     List<Submission> submissions = submissionRepository.findAllByAssignment(assignment);
 
@@ -64,7 +65,7 @@ public class SubmissionCommandService {
   }
 
   //
-  public SubmissionDto findByAssignmentId(Long assignmentId) {
+  public SubmissionDto findByAssignmentId(UUID assignmentId) {
     Assignment assignment = assignmentCommandService.findByIdOrThrow(assignmentId);
 
     Submission s = submissionRepository.findByAssignment(assignment);
@@ -79,17 +80,17 @@ public class SubmissionCommandService {
             .build();
   }
 
-  public Submission findByIdOrThrow(Long submissionId) {
+  public Submission findByIdOrThrow(UUID submissionId) {
     return submissionRepository.findById(submissionId)
             .orElseThrow(() -> new EntityNotFoundException("해당 제출 과제를 찾을수 없습니다."));
   }
 
-  public SubmissionAttachment findAssignmentAttachmentByIdOrThrow(Long submissionAttachmentId){
+  public SubmissionAttachment findAssignmentAttachmentByIdOrThrow(UUID submissionAttachmentId){
     return submissionAttachmentRepository.findById(submissionAttachmentId)
             .orElseThrow(() -> new EntityNotFoundException("해당 제출 과제를 찾을수 없습니다."));
   }
 
-  public List<SubmissionAttachmentDto> findAllAssignment(Long submissionId) {
+  public List<SubmissionAttachmentDto> findAllAssignment(UUID submissionId) {
     Submission submission = findByIdOrThrow(submissionId);
     List<SubmissionAttachment> attachments = submissionAttachmentRepository.findAllBySubmission(submission);
     return attachments.stream()
@@ -103,7 +104,7 @@ public class SubmissionCommandService {
     ).toList();
   }
 
-  public SubmissionAttachment findsubmissionAttachmentByIdOrThrow(Long submissionAttachmentId) {
+  public SubmissionAttachment findsubmissionAttachmentByIdOrThrow(UUID submissionAttachmentId) {
     return submissionAttachmentRepository.findById(submissionAttachmentId)
             .orElseThrow(() -> new EntityNotFoundException("해당 과제 제출 첨부파일을 찾을수 없습니다."));
   }

--- a/src/main/java/hello/cluebackend/domain/submission/application/SubmissionQueryService.java
+++ b/src/main/java/hello/cluebackend/domain/submission/application/SubmissionQueryService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +32,7 @@ public class SubmissionQueryService {
 
   // 해당 교실 모든 학생에게 과제 부여 & 제출 과제 생성
   @Transactional
-  public void assignToAllStudentsInClassroom(Long classroomId, Assignment assignment){
+  public void assignToAllStudentsInClassroom(UUID classroomId, Assignment assignment){
     ClassRoom classRoom = classRoomService.findById(classroomId).toEntity();
     List<UserEntity> users = classroomUserService.findAllClassroomUser(classRoom);
     List<Submission> submissions = users.stream()
@@ -42,7 +43,7 @@ public class SubmissionQueryService {
 
   // 과제 제출하기
   @Transactional
-  public Submission submitSubmission(Long submissionId) {
+  public Submission submitSubmission(UUID submissionId) {
     Submission submission = submissionCommandService.findByIdOrThrow(submissionId);
     submission.submit();
     return submissionRepository.save(submission);
@@ -50,7 +51,7 @@ public class SubmissionQueryService {
 
   // 과제 제출 취소하기
   @Transactional
-  public Submission cancelSubmission(Long submissionId) {
+  public Submission cancelSubmission(UUID submissionId) {
     Submission submission = submissionCommandService.findByIdOrThrow(submissionId);
     submission.cancel();
     return submissionRepository.save(submission);
@@ -59,7 +60,7 @@ public class SubmissionQueryService {
 
   // 첨부 파일 추가
   @Transactional
-  public SubmissionAttachment fileUpload(Long submissionId, MultipartFile file) {
+  public SubmissionAttachment fileUpload(UUID submissionId, MultipartFile file) {
     Submission submission = submissionCommandService.findByIdOrThrow(submissionId);
 
     String storedFiledName = fileService.storeFile(file);
@@ -78,7 +79,7 @@ public class SubmissionQueryService {
 
   // 첨부 링크 추가
   @Transactional
-  public SubmissionAttachment linkUpload(Long submissionId, SubmissionAttachmentUrlDto dto) {
+  public SubmissionAttachment linkUpload(UUID submissionId, SubmissionAttachmentUrlDto dto) {
     Submission submission = submissionCommandService.findByIdOrThrow(submissionId);
 
     SubmissionAttachment submissionAttachment = SubmissionAttachment.builder()
@@ -93,7 +94,7 @@ public class SubmissionQueryService {
 
   // 첨부 파일 삭제
   @Transactional
-  public void deleteSubmissionAttachment(Long submissionAttachmentId) {
+  public void deleteSubmissionAttachment(UUID submissionAttachmentId) {
     SubmissionAttachment submissionAttachment = submissionCommandService.findAssignmentAttachmentByIdOrThrow(submissionAttachmentId);
     if(submissionAttachment.getType() == fileType.file){
       fileService.deleteFile(submissionAttachment.getValue());

--- a/src/main/java/hello/cluebackend/domain/submission/domain/Submission.java
+++ b/src/main/java/hello/cluebackend/domain/submission/domain/Submission.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = "submissions")
+@Table(name = "submission")
 @Getter
 @AllArgsConstructor
 @Builder @Setter

--- a/src/main/java/hello/cluebackend/domain/submission/domain/Submission.java
+++ b/src/main/java/hello/cluebackend/domain/submission/domain/Submission.java
@@ -6,17 +6,19 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
-@Table(name = "submission")
+@Table(name = "submissions")
 @Getter
 @AllArgsConstructor
 @Builder @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Submission extends BaseEntity{
-  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "submission_id")
-  private Long submissionId;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "submission_id", nullable = false, updatable = false)
+  private UUID submissionId;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "assignment_id")

--- a/src/main/java/hello/cluebackend/domain/submission/domain/SubmissionAttachment.java
+++ b/src/main/java/hello/cluebackend/domain/submission/domain/SubmissionAttachment.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.core.io.Resource;
 
+import java.util.UUID;
+
 @Entity
 @Table(name = "submission_attachment")
 @Getter
@@ -12,9 +14,10 @@ import org.springframework.core.io.Resource;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubmissionAttachment {
-  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name="submission_attachment_id")
-  private Long SubmissionAttachmentId;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name="submission_attachment_id", nullable = false, updatable = false)
+  private UUID SubmissionAttachmentId;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name="user_id")

--- a/src/main/java/hello/cluebackend/domain/submission/persistence/SubmissionAttachmentRepository.java
+++ b/src/main/java/hello/cluebackend/domain/submission/persistence/SubmissionAttachmentRepository.java
@@ -7,8 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
-public interface SubmissionAttachmentRepository extends JpaRepository<SubmissionAttachment, Long> {
+public interface SubmissionAttachmentRepository extends JpaRepository<SubmissionAttachment, UUID> {
   List<SubmissionAttachment> findAllBySubmission(Submission submission);
 }

--- a/src/main/java/hello/cluebackend/domain/submission/persistence/SubmissionRepository.java
+++ b/src/main/java/hello/cluebackend/domain/submission/persistence/SubmissionRepository.java
@@ -6,9 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
-public interface SubmissionRepository extends JpaRepository<Submission, Long> {
+public interface SubmissionRepository extends JpaRepository<Submission, UUID> {
   List<Submission> findAllByAssignment(Assignment assignment);
 
   Submission findByAssignment(Assignment assignment);

--- a/src/main/java/hello/cluebackend/domain/user/domain/UserEntity.java
+++ b/src/main/java/hello/cluebackend/domain/user/domain/UserEntity.java
@@ -6,6 +6,7 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @ToString
 @Entity
@@ -16,11 +17,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Table(name = "user_entity")
 public class UserEntity {
-
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name="user_id", nullable = false)
-    private Long userId;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name="user_id", nullable = false, updatable = false)
+    private UUID userId;
 
     @ColumnDefault("-1")
     @Column(name="class_code")

--- a/src/main/java/hello/cluebackend/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/hello/cluebackend/domain/user/domain/repository/UserRepository.java
@@ -5,9 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
-public interface UserRepository extends JpaRepository<UserEntity, Long> {
+public interface UserRepository extends JpaRepository<UserEntity, UUID> {
     Optional<UserEntity> findByUsername(String username);
 
     Optional<UserEntity> findByEmail(String email);

--- a/src/main/java/hello/cluebackend/domain/user/presentation/TestController.java
+++ b/src/main/java/hello/cluebackend/domain/user/presentation/TestController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 @RestController
 @RequiredArgsConstructor
 public class TestController {
@@ -17,7 +19,7 @@ public class TestController {
     private final JWTUtil jwtUtil;
 
     @PostMapping("/test")
-    public ResponseEntity<?> issueToken(@RequestParam Long userId, @RequestParam String username, @RequestParam String role, HttpServletResponse response) {
+    public ResponseEntity<?> issueToken(@RequestParam UUID userId, @RequestParam String username, @RequestParam String role, HttpServletResponse response) {
         String access = jwtUtil.createJwt("access", userId, username, role, 100 * 60 * 60 * 1000L);
 
         return ResponseEntity.ok()

--- a/src/main/java/hello/cluebackend/domain/user/presentation/dto/CustomOAuth2User.java
+++ b/src/main/java/hello/cluebackend/domain/user/presentation/dto/CustomOAuth2User.java
@@ -6,6 +6,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 
 public class CustomOAuth2User implements OAuth2User {
     private final UserDto userDTO;
@@ -47,7 +48,7 @@ public class CustomOAuth2User implements OAuth2User {
         return userDTO.getUsername();
     }
 
-    public Long getUserId() {
+    public UUID getUserId() {
         return userDTO.getUserId();
     }
 

--- a/src/main/java/hello/cluebackend/domain/user/presentation/dto/UserDto.java
+++ b/src/main/java/hello/cluebackend/domain/user/presentation/dto/UserDto.java
@@ -5,6 +5,7 @@ import hello.cluebackend.domain.user.domain.UserEntity;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -12,14 +13,14 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserDto {
-    private Long userId;
+    private UUID userId;
     private String email;
     private Role role;
     private String username;
     private int classCode;
     private LocalDateTime createdAt;
 
-    public UserDto(Long userId, String email, Role role, String username, int classCode) {
+    public UserDto(UUID userId, String email, Role role, String username, int classCode) {
         this.userId = userId;
         this.email = email;
         this.role = role;

--- a/src/main/java/hello/cluebackend/domain/user/service/UserService.java
+++ b/src/main/java/hello/cluebackend/domain/user/service/UserService.java
@@ -6,6 +6,8 @@ import hello.cluebackend.domain.user.presentation.dto.DefaultRegisterUserDto;
 import hello.cluebackend.domain.user.presentation.dto.UserDto;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 public class UserService {
     private final UserRepository userRepository;
@@ -23,7 +25,7 @@ public class UserService {
         userRepository.save(userEntity);
     }
 
-    public UserDto findById(Long userId) {
+    public UserDto findById(UUID userId) {
         UserEntity userEntity = userRepository.findById(userId).get();
         return userEntity.toUserDTO();
     }

--- a/src/main/java/hello/cluebackend/global/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/hello/cluebackend/global/common/resolver/CurrentUserArgumentResolver.java
@@ -11,6 +11,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import java.util.UUID;
+
 @Component
 @RequiredArgsConstructor
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
@@ -20,7 +22,7 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
   @Override
   public boolean supportsParameter(MethodParameter parameter) {
     return parameter.hasParameterAnnotation(CurrentUser.class)
-            && parameter.getParameterType().equals(Long.class);
+            && parameter.getParameterType().equals(UUID.class);
   }
 
   @Override

--- a/src/main/java/hello/cluebackend/global/config/CustomSuccessHandler.java
+++ b/src/main/java/hello/cluebackend/global/config/CustomSuccessHandler.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.UUID;
 
 @Component
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -47,7 +48,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             );
         } else {
             String username = customUserDetails.getUsername();
-            Long userId = customUserDetails.getUserId();
+            UUID userId = customUserDetails.getUserId();
 
             Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
             Iterator<? extends GrantedAuthority> iterator = authorities.iterator();

--- a/src/main/java/hello/cluebackend/global/config/JWTFilter.java
+++ b/src/main/java/hello/cluebackend/global/config/JWTFilter.java
@@ -14,6 +14,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class JWTFilter extends OncePerRequestFilter {
     private static final AntPathRequestMatcher REFRESH_MATCHER = new AntPathRequestMatcher("/refresh-token", "POST");
@@ -53,7 +54,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String username = jwtUtil.getUsername(accessToken);
         Role role = jwtUtil.getRole(accessToken);
-        Long  userId = jwtUtil.getUserId(accessToken);
+        UUID userId = jwtUtil.getUserId(accessToken);
 
         UserDto userDTO = new UserDto();
         userDTO.setUsername(username);

--- a/src/main/java/hello/cluebackend/global/config/JWTUtil.java
+++ b/src/main/java/hello/cluebackend/global/config/JWTUtil.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 @Component
 public class JWTUtil {
@@ -22,8 +23,9 @@ public class JWTUtil {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
-    public Long getUserId(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", Long.class);
+    public UUID getUserId(String token) {
+        String uuid = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", String.class);
+        return UUID.fromString(uuid);
     }
 
     public String getUsername(String token) {
@@ -41,7 +43,6 @@ public class JWTUtil {
         return Role.valueOf(roleString);  // String → Enum
     }
 
-
     public Boolean isExpired(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
@@ -50,10 +51,7 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
     }
 
-
-
-    public String createJwt(String category, Long userId, String username, String role, Long expiredMs) {
-
+    public String createJwt(String category, UUID userId, String username, String role, Long expiredMs) {
         return  Jwts.builder()
                 .claim("category", category)
                 .claim("userId", userId)

--- a/src/main/java/hello/cluebackend/global/security/jwt/RefreshTokenService.java
+++ b/src/main/java/hello/cluebackend/global/security/jwt/RefreshTokenService.java
@@ -9,6 +9,8 @@ import org.springframework.security.authentication.AuthenticationCredentialsNotF
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @Transactional
 public class RefreshTokenService {
@@ -65,7 +67,7 @@ public class RefreshTokenService {
 
         String username = jwtUtil.getUsername(refreshToken);
         String role = jwtUtil.getRole(refreshToken).name();
-        Long userId = jwtUtil.getUserId(refreshToken);
+        UUID userId = jwtUtil.getUserId(refreshToken);
 
 
         String newAccessToken = jwtUtil.createJwt("access", userId, username, role, 60 * 10 * 1000L);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
 
   config:
     activate:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: validation
+      ddl-auto: validate
 
   config:
     activate:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validation
 
   config:
     activate:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
 
   config:
     activate:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
 
   config:
     activate:

--- a/src/test/java/hello/cluebackend/domain/classroom/presentation/ClassRoomControllerTest.java
+++ b/src/test/java/hello/cluebackend/domain/classroom/presentation/ClassRoomControllerTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -34,7 +35,7 @@ class ClassRoomControllerTest {
     void testGetAllClassRooms() {
         // given
         String token = "fake-token";
-        Long userId = 1L;
+        UUID userId = 1L;
 
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
         when(jwtUtil.getToken(mockRequest)).thenReturn(token);


### PR DESCRIPTION
모든 ID -> UUID로 변경 및 table이름 단수로 통일

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 전반적인 API 식별자를 Long에서 UUID로 전환했습니다(사용자, 클래스룸, 과제, 문서, 제출물 등). 클라이언트는 요청/응답에서 UUID를 사용해야 합니다.
  - 인증 토큰(userId)과 관련 흐름이 UUID에 맞춰 일관화되었습니다.
- Tests
  - 테스트들을 UUID 기반으로 업데이트했으며 일부 테스트 초기화 값 관련 수정 필요성이 발견되었습니다.
- Chores
  - 프로덕션 JPA 스키마 전략을 update로 변경해 엔터티 변경을 자동 반영합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->