### PR TITLE
Bug/#66

### DIFF
--- a/src/main/resources/application-dep.yml
+++ b/src/main/resources/application-dep.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
 
   config:
     activate:

--- a/src/main/resources/application-dep.yml
+++ b/src/main/resources/application-dep.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
 
   config:
     activate:

--- a/src/main/resources/application-dep.yml
+++ b/src/main/resources/application-dep.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
 
   config:
     activate:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
 
   config:
     activate:

--- a/src/test/java/hello/cluebackend/domain/classroom/presentation/ClassRoomControllerTest.java
+++ b/src/test/java/hello/cluebackend/domain/classroom/presentation/ClassRoomControllerTest.java
@@ -35,7 +35,10 @@ class ClassRoomControllerTest {
     void testGetAllClassRooms() {
         // given
         String token = "fake-token";
-        UUID userId = 1L;
+        UUID userId = UUID.randomUUID();
+
+        UUID classRoomId1 = UUID.randomUUID();
+        UUID classRoomId2 = UUID.randomUUID();
 
         HttpServletRequest mockRequest = mock(HttpServletRequest.class);
         when(jwtUtil.getToken(mockRequest)).thenReturn(token);
@@ -43,14 +46,14 @@ class ClassRoomControllerTest {
 
         List<ClassRoomCardDto> mockList = List.of(
                 ClassRoomCardDto.builder()
-                        .classRoomId(1L)
+                        .classRoomId(classRoomId1)
                         .name("자바를 자바라")
                         .sort("JAVA")
                         .target("2-2")
                         .studentCount(2)
                         .build(),
                 ClassRoomCardDto.builder()
-                        .classRoomId(2L)
+                        .classRoomId(classRoomId2)
                         .name("자바를 자바라")
                         .sort("JAVA")
                         .target("2-1")


### PR DESCRIPTION
+ Test 코드 오류 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 테스트
  - 교실 목록 조회 테스트가 숫자 ID 대신 UUID를 사용하도록 정비하여 식별자 표현을 일관화했습니다. 토큰 추출과 사용자 식별, 서비스 호출, 응답 상태/본문/항목 검증 흐름은 그대로 유지됩니다.

- Chores
  - 운영 환경에서 JPA의 스키마 자동 갱신을 비활성화했습니다. 애플리케이션 기동 시 자동으로 스키마가 변경되지 않도록 하여 배포 안정성과 예기치 않은 구조 변경을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->