### PR TITLE
bug(#75) : redirect-uri 환경변수 이름 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,7 +43,7 @@ spring:
             client-name: google
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            redirect-uri: ${REDIRECT_URI}
             authorization-grant-type: authorization_code
             scope:
               - profile


### PR DESCRIPTION
# [#75] 환경변수 이름 변경

---

## 📑 개요
환경변수 이름 변경

---

## ✅ 작업 내용
- [x] 환경변수 이름 변경
---

## 🔗 관련 이슈
Close #75 

---

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 테스트를 완료했나요?

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * OAuth2 Google 로그인 리디렉트 URI의 환경 변수 키를 GOOGLE_REDIRECT_URI에서 REDIRECT_URI로 변경했습니다. 배포 환경에서 해당 변수명을 업데이트해야 로그인 리디렉션이 정상 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->