### PR TITLE
CD수정

### DIFF
--- a/.github/workflows/Spring-develop-CD.yml
+++ b/.github/workflows/Spring-develop-CD.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
 
       - name: SSH로 EC2에 접속하기
-        uses: appleboy/ssh-action@v0.1.7
+        uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * 배포 워크플로의 SSH 단계에서 외부 액션 버전을 appleboy/ssh-action@v0.1.7에서 appleboy/ssh-action@master로 업데이트했습니다. 단계 구조와 이후 명령은 동일하며, SCP 설정도 변경 없습니다. 원격 배포의 호환성과 유지관리성이 향상될 수 있습니다. 사용자 기능에는 영향이 없으며, 서비스 중단이나 동작 변화는 예상되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->