### PR TITLE
fix(#92) : 교실 정보에 참가코드 추가

### DIFF
--- a/src/main/java/hello/cluebackend/domain/classroom/presentation/ClassRoomController.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/presentation/ClassRoomController.java
@@ -1,5 +1,6 @@
 package hello.cluebackend.domain.classroom.presentation;
 
+import hello.cluebackend.domain.classroom.presentation.dto.ClassRoomAllInfoDto;
 import hello.cluebackend.domain.classroom.presentation.dto.ClassRoomCardDto;
 import hello.cluebackend.domain.classroom.presentation.dto.ClassRoomDto;
 import hello.cluebackend.domain.classroom.service.ClassRoomService;
@@ -33,11 +34,7 @@ public class ClassRoomController {
     }
 
     @GetMapping("/{classId}/all")
-    public ResponseEntity<?> getAllInfo(HttpServletRequest request, @PathVariable UUID classId){
-        String token = jwtUtil.getToken(request);
-//        Long userId = jwtUtil.getUserId(token);
-//        Role role = jwtUtil.getRole(token);
-
+    public ResponseEntity<ClassRoomAllInfoDto> getAllInfo(@PathVariable UUID classId){
         return ResponseEntity.ok(classRoomService.getAllInfo(classId));
     }
 

--- a/src/main/java/hello/cluebackend/domain/classroom/presentation/dto/ClassRoomAllInfoDto.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/presentation/dto/ClassRoomAllInfoDto.java
@@ -18,4 +18,5 @@ public class ClassRoomAllInfoDto {
     private String description;
     private List<DirectoryAllInfoDto> directoryList;
     private List<String> teacherNames;
+    private String code;
 }

--- a/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomService.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomService.java
@@ -116,6 +116,7 @@ public class ClassRoomService {
                 .description(classRoom.getDescription())
                 .directoryList(directoryDtoList)
                 .teacherNames(teacherNames)
+                .code(classRoom.getCode())
                 .build();
     }
 }


### PR DESCRIPTION
# 📌 [#92 ] 교실 정보에 참가코드 추가

---

## 📑 개요
해당 PR에서 구현한 내용과 목적을 간단히 적어주세요.

---

## ✅ 작업 내용
- [x]  교실 정보에 참가코드 추가

---

## 🔗 관련 이슈
Close #92

---

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 테스트를 완료했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 교실 전체 정보 조회 시 교실 코드(code)가 추가로 제공됩니다. 상세 화면/데이터에서 코드를 함께 확인할 수 있습니다.
- Refactor
  - 교실 정보 조회 API가 명확한 DTO 응답으로 통일되었습니다.
  - 요청은 경로의 classId만 제공하면 되도록 단순화되었습니다.
  - 응답 구조 일관성 개선으로 클라이언트 처리 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->