### PR TITLE
Fix/#118

### DIFF
--- a/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
+++ b/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
@@ -1,15 +1,13 @@
 package hello.cluebackend.application.document.mapper;
 
-import hello.cluebackend.application.document.dto.DocumentAllInfoDto;
-import hello.cluebackend.application.document.dto.DocumentDto;
-import hello.cluebackend.application.document.dto.DownloadDto;
-import hello.cluebackend.application.document.dto.UrlDto;
+import hello.cluebackend.application.document.dto.*;
 import hello.cluebackend.domain.assignment.model.FileType;
 import hello.cluebackend.domain.classroom.model.ClassRoom;
 import hello.cluebackend.domain.directory.model.Directory;
 import hello.cluebackend.domain.document.model.Document;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 @Component
 public class DocumentMapper {
@@ -28,6 +26,14 @@ public class DocumentMapper {
                 .build();
     }
 
+    public DownloadDto toDownloadDto(Document document, Resource resource) {
+        return DownloadDto.builder()
+                .original(document.getOriginalFileName())
+                .contentType(document.getContentType())
+                .resource(resource)
+                .build();
+    }
+
     public Document fromUrlDtoToDocument(UrlDto urlDto, ClassRoom classRoom, Directory directory) {
         return Document.builder()
                 .title(urlDto.getTitle())
@@ -38,11 +44,16 @@ public class DocumentMapper {
                 .build();
     }
 
-    public DownloadDto toDownloadDto(Document document, Resource resource) {
-        return DownloadDto.builder()
-                .original(document.getOriginalFileName())
-                .contentType(document.getContentType())
-                .resource(resource)
+    public Document fromRequestDocumentDtoToDocument(RequestDocumentDto requestDocumentDto, ClassRoom classRoom, Directory directory, String storedFileName, MultipartFile file) {
+        return Document.builder()
+                .classRoom(classRoom)
+                .directory(directory)
+                .title(requestDocumentDto.getTitle())
+                .type(FileType.FILE)
+                .value(storedFileName)
+                .originalFileName(file.getOriginalFilename())
+                .contentType(file.getContentType())
+                .size(file.getSize())
                 .build();
     }
 }

--- a/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
+++ b/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
@@ -2,11 +2,13 @@ package hello.cluebackend.application.document.mapper;
 
 import hello.cluebackend.application.document.dto.DocumentAllInfoDto;
 import hello.cluebackend.application.document.dto.DocumentDto;
+import hello.cluebackend.application.document.dto.DownloadDto;
 import hello.cluebackend.application.document.dto.UrlDto;
 import hello.cluebackend.domain.assignment.model.FileType;
 import hello.cluebackend.domain.classroom.model.ClassRoom;
 import hello.cluebackend.domain.directory.model.Directory;
 import hello.cluebackend.domain.document.model.Document;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -26,6 +28,14 @@ public class DocumentMapper {
                 .directory(directory)
                 .type(FileType.URL)
                 .value(urlDto.getValue())
+                .build();
+    }
+
+    public DownloadDto toDownloadDto(Document document, Resource resource) {
+        return DownloadDto.builder()
+                .original(document.getOriginalFileName())
+                .contentType(document.getContentType())
+                .resource(resource)
                 .build();
     }
 }

--- a/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
+++ b/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
@@ -21,6 +21,13 @@ public class DocumentMapper {
                 .build();
     }
 
+    public UrlDto toUrlDto(Document document) {
+        return UrlDto.builder()
+                .value(document.getValue())
+                .title(document.getTitle())
+                .build();
+    }
+
     public Document fromUrlDtoToDocument(UrlDto urlDto, ClassRoom classRoom, Directory directory) {
         return Document.builder()
                 .title(urlDto.getTitle())

--- a/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
+++ b/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
@@ -1,6 +1,10 @@
 package hello.cluebackend.application.document.mapper;
 
 import hello.cluebackend.application.document.dto.DocumentAllInfoDto;
+import hello.cluebackend.application.document.dto.UrlDto;
+import hello.cluebackend.domain.assignment.model.FileType;
+import hello.cluebackend.domain.classroom.model.ClassRoom;
+import hello.cluebackend.domain.directory.model.Directory;
 import hello.cluebackend.domain.document.model.Document;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +15,16 @@ public class DocumentMapper {
                 .documentId(document.getDocumentId())
                 .title(document.getTitle())
                 .createdAt(document.getCreatedAt())
+                .build();
+    }
+
+    public Document fromUrlDtoToDocument(UrlDto urlDto, ClassRoom classRoom, Directory directory) {
+        return Document.builder()
+                .title(urlDto.getTitle())
+                .classRoom(classRoom)
+                .directory(directory)
+                .type(FileType.URL)
+                .value(urlDto.getValue())
                 .build();
     }
 }

--- a/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
+++ b/src/main/java/hello/cluebackend/application/document/mapper/DocumentMapper.java
@@ -1,6 +1,7 @@
 package hello.cluebackend.application.document.mapper;
 
 import hello.cluebackend.application.document.dto.DocumentAllInfoDto;
+import hello.cluebackend.application.document.dto.DocumentDto;
 import hello.cluebackend.application.document.dto.UrlDto;
 import hello.cluebackend.domain.assignment.model.FileType;
 import hello.cluebackend.domain.classroom.model.ClassRoom;

--- a/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
+++ b/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
@@ -51,11 +51,7 @@ public class DocumentService {
         ClassRoom findClassRoom = classRoomJpaRepository.findById(classRoomId).orElseThrow(() -> new EntityNotFoundException("해당 교실을 찾을 수가 없습니다."));
         Directory findDirectory = directoryJpaRepository.findById(directoryId).orElseThrow(() -> new EntityNotFoundException("해당 디렉토리를 찾을 수가 없습니다."));
 
-        log.info("requestDocumentDto size: {}", requestDocumentDto.size());
-        log.info("files size: {}", files.size());
-        if(requestDocumentDto.size() != files.size()) {
-            throw new RuntimeException("한쪽 요소 부족");
-        }
+        validateFileSize(requestDocumentDto, files);
         for(int i = 0; i < requestDocumentDto.size(); i++) {
             try {
                 MultipartFile file = files.get(i);
@@ -103,5 +99,11 @@ public class DocumentService {
             return documentMapper.toUrlDto(document);
         }
         return null;
+    }
+
+    public void validateFileSize(List<RequestDocumentDto> requestDocumentDto, List<MultipartFile> files) {
+        if(requestDocumentDto.size() != files.size()) {
+            throw new RuntimeException("한쪽 요소 부족");
+        }
     }
 }

--- a/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
+++ b/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
@@ -94,11 +94,7 @@ public class DocumentService {
     public DownloadDto downloadDocument(UUID documentId) throws IOException {
         Document document = documentJpaRepository.findById(documentId).orElseThrow(() -> new EntityNotFoundException("해당 수업자료가 존재하지 않습니다."));
         Resource resource = fileService.downloadFile(document.getValue());
-        return DownloadDto.builder()
-                .original(document.getOriginalFileName())
-                .contentType(document.getContentType())
-                .resource(resource)
-                .build();
+        return documentMapper.toDownloadDto(document, resource);
     }
 
     public UrlDto getLink(UUID documentId) {

--- a/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
+++ b/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
@@ -52,6 +52,7 @@ public class DocumentService {
         Directory findDirectory = directoryJpaRepository.findById(directoryId).orElseThrow(() -> new EntityNotFoundException("해당 디렉토리를 찾을 수가 없습니다."));
 
         validateFileSize(requestDocumentDto, files);
+
         for(int i = 0; i < requestDocumentDto.size(); i++) {
             try {
                 MultipartFile file = files.get(i);

--- a/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
+++ b/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
@@ -57,16 +57,7 @@ public class DocumentService {
                 MultipartFile file = files.get(i);
                 RequestDocumentDto requestDocument = requestDocumentDto.get(i);
                 String storedFileName = fileService.storeFile(file);
-                Document document = Document.builder()
-                        .classRoom(findClassRoom)
-                        .directory(findDirectory)
-                        .title(requestDocument.getTitle())
-                        .type(FileType.FILE)
-                        .value(storedFileName)
-                        .originalFileName(file.getOriginalFilename())
-                        .contentType(file.getContentType())
-                        .size(file.getSize())
-                        .build();
+                Document document = documentMapper.fromRequestDocumentDtoToDocument(requestDocument,findClassRoom, findDirectory, storedFileName, file);
                 documentJpaRepository.save(document);
             } catch(Exception e) {
                 throw new RuntimeException("파일 저장 중 에러 발생");

--- a/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
+++ b/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
@@ -91,11 +91,6 @@ public class DocumentService {
         documentJpaRepository.delete(document);
     }
 
-    public DocumentDto findById(UUID documentId) {
-        Document findDocument = documentJpaRepository.findById(documentId).orElseThrow(() -> new IllegalArgumentException("해당 수업자료가 존재하지 않습니다."));
-        return findDocument.toDto();
-    }
-
     public DownloadDto downloadDocument(UUID documentId) throws IOException {
         Document document = documentJpaRepository.findById(documentId).orElseThrow(() -> new EntityNotFoundException("해당 수업자료가 존재하지 않습니다."));
         Resource resource = fileService.downloadFile(document.getValue());

--- a/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
+++ b/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
@@ -100,10 +100,7 @@ public class DocumentService {
     public UrlDto getLink(UUID documentId) {
         Document document = documentJpaRepository.findById(documentId).orElseThrow(() -> new EntityNotFoundException("해당 수업자료가 존재하지 않습니다."));
         if(document.getType() == FileType.URL) {
-            return UrlDto.builder()
-                    .value(document.getValue())
-                    .title(document.getTitle())
-                    .build();
+            return documentMapper.toUrlDto(document);
         }
         return null;
     }

--- a/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
+++ b/src/main/java/hello/cluebackend/domain/document/service/DocumentService.java
@@ -1,6 +1,7 @@
 package hello.cluebackend.domain.document.service;
 
 import hello.cluebackend.application.document.dto.*;
+import hello.cluebackend.application.document.mapper.DocumentMapper;
 import hello.cluebackend.domain.assignment.model.FileType;
 import hello.cluebackend.domain.classroom.model.ClassRoom;
 import hello.cluebackend.infrastructure.persistence.classroom.ClassRoomJpaRepository;
@@ -35,18 +36,13 @@ public class DocumentService {
     private final ClassRoomJpaRepository classRoomJpaRepository;
     private final DirectoryJpaRepository directoryJpaRepository;
     private final FileService fileService;
+    private final DocumentMapper documentMapper;
 
     public void uploadUrlDocument(InfoDto urlDto) {
         ClassRoom classRoom = classRoomJpaRepository.findById(urlDto.getClassRoomId()).orElseThrow(() -> new EntityNotFoundException("해당 교실을 찾을 수가 없습니다."));
         Directory directory = directoryJpaRepository.findById(urlDto.getDirectoryId()).orElseThrow(() -> new EntityNotFoundException("해당 디렉토리를 찾을 수가 없습니다."));
         for (UrlDto dto : urlDto.getUrls()) {
-            Document document = Document.builder()
-                    .title(dto.getTitle())
-                    .classRoom(classRoom)
-                    .directory(directory)
-                    .type(FileType.URL)
-                    .value(dto.getValue())
-                    .build();
+            Document document = documentMapper.fromUrlDtoToDocument(dto, classRoom, directory);
             documentJpaRepository.save(document);
         }
     }

--- a/src/main/java/hello/cluebackend/domain/notice/controller/NoticeController.java
+++ b/src/main/java/hello/cluebackend/domain/notice/controller/NoticeController.java
@@ -34,7 +34,7 @@ public class NoticeController {
     public ResponseEntity<Void> createNotice(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
             @RequestPart(value = "metadata") CreateNoticeDto createNoticeDto,
-            @RequestPart(value = "files") List<MultipartFile> files
+            @RequestPart(value = "files", required = false) List<MultipartFile> files
             ) {
         UUID userId = customOAuth2User.getUserDTO().getUserId();
 
@@ -78,7 +78,7 @@ public class NoticeController {
     @GetMapping
     public ResponseEntity<List<NoticeDto>> getAllNotices(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         UUID userId = customOAuth2User.getUserDTO().getUserId();
-        return ResponseEntity.status(HttpStatus.OK).body(noticeService.findAllById(userId));
+        return ResponseEntity.status(HttpStatus.OK).body(noticeService.findAllById());
     }
 
     @GetMapping("/{noticeId}")

--- a/src/main/java/hello/cluebackend/domain/notice/service/NoticeService.java
+++ b/src/main/java/hello/cluebackend/domain/notice/service/NoticeService.java
@@ -63,8 +63,7 @@ public class NoticeService {
 
         em.flush();
         em.clear();
-
-        if(dto.getFileInfo().size() != files.size()){
+        if(files!=null && dto.getFileInfo().size() != files.size()){
             throw new RuntimeException("한쪽 요소 부족");
         }
 
@@ -112,8 +111,8 @@ public class NoticeService {
     }
 
     @Transactional(readOnly = true)
-    public List<NoticeDto> findAllById(UUID userId) {
-        return noticeRepository.findAllByUserId(userId).stream()
+    public List<NoticeDto> findAllById() {
+        return noticeRepository.findAll().stream()
                 .map(Notice::toDto).toList();
     }
 

--- a/src/main/java/hello/cluebackend/presentation/api/document/DocumentController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/document/DocumentController.java
@@ -2,7 +2,6 @@ package hello.cluebackend.presentation.api.document;
 
 import hello.cluebackend.application.document.dto.*;
 import hello.cluebackend.domain.document.service.DocumentService;
-import hello.cluebackend.domain.user.model.Role;
 import hello.cluebackend.application.user.dto.CustomOAuth2User;
 
 import jakarta.validation.constraints.NotNull;
@@ -10,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
-import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,49 +27,28 @@ public class DocumentController {
 
     private final DocumentService documentService;
 
+    @PreAuthorize("hasRole('ROLE_TEACHER')")
     @PostMapping(value = "/file")
     public ResponseEntity<Void> uploadDocument(
             @RequestPart(value = "metadata") List<RequestDocumentDto> requestDocumentDto,
             @RequestPart(value = "files") @NotNull List<MultipartFile> files,
             @RequestParam(value = "classRoomId") UUID classRoomId,
-            @RequestParam(value = "directoryId") UUID directoryId,
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        Role role = customOAuth2User.getUserDTO().getRole();
-
-        if(role == Role.TEACHER) {
-            documentService.uploadFileDocument(classRoomId, directoryId, requestDocumentDto, files);
-            return ResponseEntity.ok().build();
-        }
-        else {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-
+            @RequestParam(value = "directoryId") UUID directoryId) {
+        documentService.uploadFileDocument(classRoomId, directoryId, requestDocumentDto, files);
+        return ResponseEntity.ok().build();
     }
 
+    @PreAuthorize("hasRole('ROLE_TEACHER')")
     @PatchMapping
     public ResponseEntity<Void> updateDocument(
-            @RequestBody UpdateFileDto fileDto,
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-
-        Role role = customOAuth2User.getUserDTO().getRole();
-
-        if(role == Role.TEACHER) {
-            documentService.updateDocument(fileDto);
-            return ResponseEntity.ok().build();
-        }
-        else {
-            throw new AuthorizationDeniedException("권한이 부족합니다.");
-        }
+            @RequestBody UpdateFileDto fileDto) {
+        documentService.updateDocument(fileDto);
+        return ResponseEntity.ok().build();
     }
 
+    @PreAuthorize("hasRole('ROLE_TEACHER')")
     @DeleteMapping("/{documentId}")
-    public ResponseEntity<?> deleteDocument(@PathVariable("documentId") UUID documentId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        Role role = customOAuth2User.getUserDTO().getRole();
-
-        if(role != Role.TEACHER) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-
+    public ResponseEntity<?> deleteDocument(@PathVariable("documentId") UUID documentId) {
         try {
             documentService.deleteDocument(documentId);
         } catch (RuntimeException e) {
@@ -98,8 +76,9 @@ public class DocumentController {
                 .body(dto.getResource());
     }
 
+    @PreAuthorize("hasRole('ROLE_TEACHER')")
     @PostMapping("/link")
-    public ResponseEntity<Void> urlUpload(@RequestBody InfoDto urlDto, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+    public ResponseEntity<Void> urlUpload(@RequestBody InfoDto urlDto) {
         documentService.uploadUrlDocument(urlDto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/hello/cluebackend/presentation/api/document/DocumentController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/document/DocumentController.java
@@ -5,6 +5,7 @@ import hello.cluebackend.domain.document.service.DocumentService;
 import hello.cluebackend.domain.user.model.Role;
 import hello.cluebackend.application.user.dto.CustomOAuth2User;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
@@ -30,7 +31,7 @@ public class DocumentController {
     @PostMapping(value = "/file")
     public ResponseEntity<Void> uploadDocument(
             @RequestPart(value = "metadata") List<RequestDocumentDto> requestDocumentDto,
-            @RequestPart(value = "files")  List<MultipartFile> files,
+            @RequestPart(value = "files") @NotNull List<MultipartFile> files,
             @RequestParam(value = "classRoomId") UUID classRoomId,
             @RequestParam(value = "directoryId") UUID directoryId,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {


### PR DESCRIPTION
# [#118] 수업자료 도메인 모델 재구성

---

## 📑 개요
수업자료 도메인 모델을 DDD 원칙에 맞게 재구성하였습니다.

---

## ✅ 작업 내용
- [x] 각 도메인에 Mapper 클래스 추가
- [x] 수업자료 도메인에 비지니스 로직 추가
- [x] 수업자료 관련 api 권한 인증 로직 변경
---

## 🔗 관련 이슈
Close #118

—

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트를 완료했나요?
