### PR TITLE
Fix/#146

### DIFF
--- a/src/main/java/hello/cluebackend/application/directory/dto/DirectoryAllInfoDto.java
+++ b/src/main/java/hello/cluebackend/application/directory/dto/DirectoryAllInfoDto.java
@@ -14,6 +14,6 @@ import java.util.UUID;
 public class DirectoryAllInfoDto {
     private UUID directoryId;
     private String directoryName;
-    private int directoryOrder;
+    // private int directoryOrder;
     private List<DocumentAllInfoDto> documentList;
 }

--- a/src/main/java/hello/cluebackend/application/directory/dto/DirectoryAllInfoDto.java
+++ b/src/main/java/hello/cluebackend/application/directory/dto/DirectoryAllInfoDto.java
@@ -14,6 +14,5 @@ import java.util.UUID;
 public class DirectoryAllInfoDto {
     private UUID directoryId;
     private String directoryName;
-    // private int directoryOrder;
     private List<DocumentAllInfoDto> documentList;
 }

--- a/src/main/java/hello/cluebackend/application/directory/dto/DirectoryDto.java
+++ b/src/main/java/hello/cluebackend/application/directory/dto/DirectoryDto.java
@@ -18,5 +18,4 @@ public class DirectoryDto {
     private UUID directoryId;
     private ClassRoom classRoom;
     private String name;
-//    private int directoryOrder;
 }

--- a/src/main/java/hello/cluebackend/application/directory/dto/DirectoryDto.java
+++ b/src/main/java/hello/cluebackend/application/directory/dto/DirectoryDto.java
@@ -18,14 +18,5 @@ public class DirectoryDto {
     private UUID directoryId;
     private ClassRoom classRoom;
     private String name;
-    private int directoryOrder;
-
-    public Directory toDto() {
-        return Directory.builder()
-                .directoryId(directoryId)
-                .classRoom(classRoom)
-                .name(name)
-                .directoryOrder(directoryOrder)
-                .build();
-    }
+//    private int directoryOrder;
 }

--- a/src/main/java/hello/cluebackend/application/directory/dto/RequestDirectoryDto.java
+++ b/src/main/java/hello/cluebackend/application/directory/dto/RequestDirectoryDto.java
@@ -9,5 +9,4 @@ public class RequestDirectoryDto {
     private UUID directoryId;
     private UUID classRoomId;
     private String name;
-    private int directoryOrder;
 }

--- a/src/main/java/hello/cluebackend/application/directory/mapper/DirectoryMapper.java
+++ b/src/main/java/hello/cluebackend/application/directory/mapper/DirectoryMapper.java
@@ -13,7 +13,7 @@ public class DirectoryMapper {
         return DirectoryAllInfoDto.builder()
                 .directoryId(directory.getDirectoryId())
                 .directoryName(directory.getName())
-                .directoryOrder(directory.getDirectoryOrder())
+//                .directoryOrder(directory.getDirectoryOrder())
                 .documentList(documentDtoList)
                 .build();
     }

--- a/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomQueryService.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomQueryService.java
@@ -57,7 +57,8 @@ public class ClassRoomQueryService {
     ClassRoom classRoom = classRoomJpaRepository.findById(classId)
       .orElseThrow(() -> new IllegalArgumentException("해당 수업이 존재하지 않습니다."));
     List<DirectoryAllInfoDto> directoryDtoList = classRoom.getDirectoryList().stream()
-            .sorted(Comparator.comparingInt(Directory::getDirectoryOrder))
+//            .sorted(Comparator.comparingInt(Directory::getDirectoryOrder))
+            .sorted(Comparator.comparing(Directory::getCreatedAt))
             .map(directory -> {
               List<DocumentAllInfoDto> documentDtoList = directory.getDocumentList().stream()
                       .sorted(Comparator.comparing(Document::getCreatedAt))

--- a/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomQueryService.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomQueryService.java
@@ -57,7 +57,6 @@ public class ClassRoomQueryService {
     ClassRoom classRoom = classRoomJpaRepository.findById(classId)
       .orElseThrow(() -> new IllegalArgumentException("해당 수업이 존재하지 않습니다."));
     List<DirectoryAllInfoDto> directoryDtoList = classRoom.getDirectoryList().stream()
-//            .sorted(Comparator.comparingInt(Directory::getDirectoryOrder))
             .sorted(Comparator.comparing(Directory::getCreatedAt))
             .map(directory -> {
               List<DocumentAllInfoDto> documentDtoList = directory.getDocumentList().stream()

--- a/src/main/java/hello/cluebackend/domain/directory/model/Directory.java
+++ b/src/main/java/hello/cluebackend/domain/directory/model/Directory.java
@@ -1,5 +1,6 @@
 package hello.cluebackend.domain.directory.model;
 
+import hello.cluebackend.application.directory.dto.RequestDirectoryDto;
 import hello.cluebackend.domain.classroom.model.ClassRoom;
 import hello.cluebackend.application.directory.dto.DirectoryDto;
 import hello.cluebackend.domain.document.model.Document;
@@ -38,5 +39,9 @@ public class Directory {
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
+    }
+
+    public void update(RequestDirectoryDto requestDirectoryDto) {
+        this.name = requestDirectoryDto.getName();
     }
 }

--- a/src/main/java/hello/cluebackend/domain/directory/model/Directory.java
+++ b/src/main/java/hello/cluebackend/domain/directory/model/Directory.java
@@ -6,6 +6,7 @@ import hello.cluebackend.domain.document.model.Document;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -28,18 +29,14 @@ public class Directory {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
-    private int directoryOrder;
+    @Column(nullable = true)
+    private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "directory", cascade = CascadeType.ALL)
     private List<Document> documentList;
 
-    public DirectoryDto  toDto() {
-        return DirectoryDto.builder()
-                .directoryId(directoryId)
-                .classRoom(classRoom)
-                .name(name)
-                .directoryOrder(directoryOrder)
-                .build();
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/hello/cluebackend/domain/directory/service/DirectoryService.java
+++ b/src/main/java/hello/cluebackend/domain/directory/service/DirectoryService.java
@@ -33,10 +33,6 @@ public class DirectoryService {
     }
 
     public void deleteById(UUID directoryId) {
-        try {
-            directoryJpaRepository.deleteById(directoryId);
-        } catch(Exception e) {
-            throw e;
-        }
+        directoryJpaRepository.deleteById(directoryId);
     }
 }

--- a/src/main/java/hello/cluebackend/domain/directory/service/DirectoryService.java
+++ b/src/main/java/hello/cluebackend/domain/directory/service/DirectoryService.java
@@ -22,7 +22,6 @@ public class DirectoryService {
         Directory directory = Directory.builder()
                 .name(requestDirectoryDto.getName())
                 .classRoom(findClassRoom)
-                .directoryOrder(requestDirectoryDto.getDirectoryOrder())
                 .build();
         directoryJpaRepository.save(directory);
     }
@@ -30,9 +29,7 @@ public class DirectoryService {
     public void updateDirectory(RequestDirectoryDto requestDirectoryDto) {
         ClassRoom findClassRoom = classRoomJpaRepository.findById(requestDirectoryDto.getClassRoomId()).orElseThrow(() -> new IllegalArgumentException("해당 수업이 존재하지 않습니다."));
         Directory directory = directoryJpaRepository.findById(requestDirectoryDto.getDirectoryId()).orElseThrow(() -> new IllegalArgumentException("해당 디렉토리가 존재하지 않습니다."));
-
         directory.setName(requestDirectoryDto.getName());
-        directory.setDirectoryOrder(requestDirectoryDto.getDirectoryOrder());
         directory.setClassRoom(findClassRoom);
 
         directoryJpaRepository.save(directory);

--- a/src/main/java/hello/cluebackend/domain/directory/service/DirectoryService.java
+++ b/src/main/java/hello/cluebackend/domain/directory/service/DirectoryService.java
@@ -27,11 +27,8 @@ public class DirectoryService {
     }
 
     public void updateDirectory(RequestDirectoryDto requestDirectoryDto) {
-        ClassRoom findClassRoom = classRoomJpaRepository.findById(requestDirectoryDto.getClassRoomId()).orElseThrow(() -> new IllegalArgumentException("해당 수업이 존재하지 않습니다."));
         Directory directory = directoryJpaRepository.findById(requestDirectoryDto.getDirectoryId()).orElseThrow(() -> new IllegalArgumentException("해당 디렉토리가 존재하지 않습니다."));
-        directory.setName(requestDirectoryDto.getName());
-        directory.setClassRoom(findClassRoom);
-
+        directory.update(requestDirectoryDto);
         directoryJpaRepository.save(directory);
     }
 

--- a/src/main/java/hello/cluebackend/presentation/api/directory/DirectoryController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/directory/DirectoryController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,36 +22,24 @@ public class DirectoryController {
     private final DirectoryService directoryService;
     private final UserService userService;
 
+    @PreAuthorize("hasRole('TEACHER')")
     @PostMapping
-    public ResponseEntity<?> createDirectory(
-            @RequestBody RequestDirectoryDto requestDirectoryDto,
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
-    ){
-        UserEntity user = userService.findById(customOAuth2User.getUserId());
-        if(!user.getRole().equals(Role.TEACHER)) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    public ResponseEntity<?> createDirectory(@RequestBody RequestDirectoryDto requestDirectoryDto) {
         directoryService.createDirectory(requestDirectoryDto);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @PreAuthorize("hasRole('TEACHER')")
     @PatchMapping
-    public ResponseEntity<?> updateDirectory(
-            @RequestBody RequestDirectoryDto requestDirectoryDto,
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
-    ){
-      UserEntity user = userService.findById(customOAuth2User.getUserId());
-      if(!user.getRole().equals(Role.TEACHER)) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    public ResponseEntity<Void> updateDirectory(@RequestBody RequestDirectoryDto requestDirectoryDto) {
       directoryService.updateDirectory(requestDirectoryDto);
-      return new ResponseEntity<>(HttpStatus.OK);
+      return ResponseEntity.status(HttpStatus.OK).build();
     }
 
+    @PreAuthorize("hasRole('TEACHER')")
     @DeleteMapping
-    public ResponseEntity<?> deleteDirectory(
-            @RequestBody RequestDirectoryDto requestDirectoryDto,
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
-    ) {
-      UserEntity user = userService.findById(customOAuth2User.getUserId());
-      if(!user.getRole().equals(Role.TEACHER)) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    public ResponseEntity<Void> deleteDirectory(@RequestBody RequestDirectoryDto requestDirectoryDto) {
       directoryService.deleteById(requestDirectoryDto.getDirectoryId());
-      return new ResponseEntity<>(HttpStatus.OK);
+      return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/hello/cluebackend/presentation/api/directory/DirectoryController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/directory/DirectoryController.java
@@ -2,16 +2,11 @@ package hello.cluebackend.presentation.api.directory;
 
 import hello.cluebackend.application.directory.dto.RequestDirectoryDto;
 import hello.cluebackend.domain.directory.service.DirectoryService;
-import hello.cluebackend.domain.user.model.Role;
-import hello.cluebackend.domain.user.model.UserEntity;
-import hello.cluebackend.application.user.dto.oauth2.CustomOAuth2User;
-import hello.cluebackend.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -19,14 +14,14 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/directory")
 @RequiredArgsConstructor
 public class DirectoryController {
+
     private final DirectoryService directoryService;
-    private final UserService userService;
 
     @PreAuthorize("hasRole('TEACHER')")
     @PostMapping
-    public ResponseEntity<?> createDirectory(@RequestBody RequestDirectoryDto requestDirectoryDto) {
+    public ResponseEntity<Void> createDirectory(@RequestBody RequestDirectoryDto requestDirectoryDto) {
         directoryService.createDirectory(requestDirectoryDto);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PreAuthorize("hasRole('TEACHER')")


### PR DESCRIPTION
# [#146] 디렉토리를 날짜 기준으로 정렬하도록 변경

---

## 📑 개요

기존에는 디렉토리를 directoryOrder 기준으로 정렬해 조회했으나,
사용성과 요구사항을 고려해 디렉토리 생성일(createdAt) 기준으로 정렬하도록 변경했습니다.

또한 기존의 서비스의 권한 체크 로직을 제거하고,
@PreAuthorize 기반 권한 인증 방식으로 개선했습니다.

---

✅ 작업 내용

- [x]  정렬 기준을 directoryOrder → createdAt DESC로 변경

- [x] 권한 체크 방식을 서비스 내부 로직에서 @PreAuthorize 기반 검증으로 변경

- [x] 기존 중복되는 권한 검사 코드 제거
---

🔗 관련 이슈
Close #146

---

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트를 완료했나요?