### PR TITLE
CB-1-과제-API-오류-수정

### DIFF
--- a/src/main/java/hello/cluebackend/application/submission/dto/response/SubmissionResponse.java
+++ b/src/main/java/hello/cluebackend/application/submission/dto/response/SubmissionResponse.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.UUID;
 
 public record SubmissionResponse(
+        UUID classId,
+        UUID assignmentId,
         String title,
         String content,
         LocalDateTime startDate,
@@ -22,6 +24,8 @@ public record SubmissionResponse(
 ) {
   public static SubmissionResponse from(Submission submission, List<SubmissionAttachmentResponse> sa) {
     return new SubmissionResponse(
+            submission.getClassRoom().getClassRoomId(),
+            submission.getAssignment().getAssignmentId(),
             submission.getAssignment().getTitle(),
             submission.getAssignment().getContent(),
             submission.getAssignment().getStartDate(),

--- a/src/main/java/hello/cluebackend/domain/classroom/exception/AlreadyJoinedClassRoomException.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/exception/AlreadyJoinedClassRoomException.java
@@ -1,0 +1,11 @@
+package hello.cluebackend.domain.classroom.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class AlreadyJoinedClassRoomException extends RuntimeException {
+  public AlreadyJoinedClassRoomException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomCommandService.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/service/ClassRoomCommandService.java
@@ -2,6 +2,7 @@ package hello.cluebackend.domain.classroom.service;
 
 import hello.cluebackend.application.classroom.dto.ClassRoomDto;
 import hello.cluebackend.application.classroom.mapper.ClassRoomMapper;
+import hello.cluebackend.domain.classroom.exception.AlreadyJoinedClassRoomException;
 import hello.cluebackend.domain.classroom.model.ClassRoom;
 import hello.cluebackend.domain.user.service.UserService;
 import hello.cluebackend.infrastructure.persistence.classroom.ClassRoomJpaRepository;
@@ -55,6 +56,11 @@ public class ClassRoomCommandService {
   public void joinClassRoom(UUID userId, String code) {
     ClassRoom findClassRoom = classRoomJpaRepository.findByCode(code).orElseThrow(() -> new EntityNotFoundException("classroom not found"));
     UserEntity findUser = userService.findById(userId);
+
+    if (classRoomUserJpaRepository.existsByClassRoomAndUser(findClassRoom, findUser)) {
+      throw new AlreadyJoinedClassRoomException("이미 참여한 교실입니다.");
+    }
+
     ClassRoomUser classRoomUser = ClassRoomUser.create(findClassRoom, findUser);
     classRoomUserJpaRepository.save(classRoomUser);
   }

--- a/src/main/java/hello/cluebackend/presentation/api/classroom/ClassRoomQueryController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/classroom/ClassRoomQueryController.java
@@ -22,21 +22,24 @@ public class ClassRoomQueryController {
     private final ClassRoomQueryService classRoomQueryService;
 
     @GetMapping
-    public ResponseEntity<List<ClassRoomCardDto>> getAllClassRooms(@AuthenticationPrincipal CustomOAuth2User customOAuth2User){
+    public ResponseEntity<List<ClassRoomCardDto>> getAllClassRooms(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+    ) {
         return ResponseEntity.ok(classRoomQueryService.findMyClassRoomById(customOAuth2User.getUserId()));
     }
 
     @GetMapping("/{classId}/all")
     public ResponseEntity<ClassRoomAllInfoDto> getAllInfo(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
             @PathVariable UUID classId
-    ){
+    ) {
         return ResponseEntity.ok(classRoomQueryService.getAllInfo(classId));
     }
 
     @GetMapping("/{classId}")
     public ResponseEntity<ClassRoomDto> findClassRoom(
-            @PathVariable UUID classId,
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @PathVariable UUID classId
     ) {
       ClassRoomDto findClassRoomDto = classRoomQueryService.findById(customOAuth2User.getUserId(), classId);
       return ResponseEntity.ok(findClassRoomDto);


### PR DESCRIPTION
  ## 🔧 과제 API 오류 수정

  ### 📌 관련 이슈
  - Close #150

  ### 🎯 작업 내용

  #### 1. 교실 중복 참여 방지 기능 추가
  - `AlreadyJoinedClassRoomException` 추가
  - `ClassRoomCommandService.joinClassRoom()` 메서드에 중복 참여 체크 로직 추가
  - 이미 참여한 교실에 재참여 시도 시 명확한 에러 메시지 반환

  #### 3. SubmissionResponse 필드 추가
  - `classId`, `assignmentId` 필드 추가
  - 과제 제출 응답에 교실 ID와 과제 ID 포함