### PR TITLE
Fix/#153

### DIFF
--- a/src/main/java/hello/cluebackend/domain/assignment/model/Assignment.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/model/Assignment.java
@@ -48,6 +48,9 @@ public class Assignment {
   @JsonIgnore
   private List<Submission> submissions = new ArrayList<>();
 
+  @OneToMany(mappedBy = "assignment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<AssignmentAttachment> attachments = new ArrayList<>();
+
   // DTO 기반 정적 팩토리 메서드
   public static Assignment create(ClassRoom classRoom, UserEntity user, String title, String content, LocalDateTime startDate, LocalDateTime endDate) {
     return Assignment.builder()

--- a/src/main/java/hello/cluebackend/domain/classroom/model/ClassRoom.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/model/ClassRoom.java
@@ -2,6 +2,7 @@ package hello.cluebackend.domain.classroom.model;
 
 import hello.cluebackend.application.classroom.dto.ClassRoomCardDto;
 import hello.cluebackend.application.classroom.dto.ClassRoomDto;
+import hello.cluebackend.domain.assignment.model.Assignment;
 import hello.cluebackend.domain.classroomuser.model.ClassRoomUser;
 import hello.cluebackend.domain.directory.model.Directory;
 import hello.cluebackend.domain.document.model.Document;
@@ -11,6 +12,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -53,13 +55,16 @@ public class ClassRoom {
     }
 
     @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL)
-    private List<ClassRoomUser> classRoomUserList;
+    private List<ClassRoomUser> classRoomUserList = new ArrayList<>();
 
     @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL)
-    private List<Directory>  directoryList;
+    private List<Directory>  directoryList = new ArrayList<>();
 
     @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL)
-    private List<Document> documentList;
+    private List<Document> documentList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL)
+    private List<Assignment> assignmentList = new ArrayList<>();
 
     public ClassRoomDto toDTO() {
         List<String> teacherNames = classRoomUserList.stream()

--- a/src/main/java/hello/cluebackend/domain/classroom/model/ClassRoom.java
+++ b/src/main/java/hello/cluebackend/domain/classroom/model/ClassRoom.java
@@ -54,16 +54,16 @@ public class ClassRoom {
         createdAt = LocalDateTime.now();
     }
 
-    @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL,  orphanRemoval = true)
     private List<ClassRoomUser> classRoomUserList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Directory>  directoryList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Document> documentList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "classRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Assignment> assignmentList = new ArrayList<>();
 
     public ClassRoomDto toDTO() {

--- a/src/main/java/hello/cluebackend/presentation/api/classroom/ClassRoomCommandController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/classroom/ClassRoomCommandController.java
@@ -57,11 +57,11 @@ public class ClassRoomCommandController {
 
 
   @DeleteMapping("/{classId}")
-  public ResponseEntity<?> deleteClassRoom(
+  public ResponseEntity<Void> deleteClassRoom(
           @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
           @PathVariable UUID classId
   ) {
     classRoomCommandService.deleteClassRoom(customOAuth2User.getUserId(), classId);
-    return ResponseEntity.noContent().build();
+    return ResponseEntity.status(HttpStatus.OK).build();
   }
 }


### PR DESCRIPTION
# [#153]  ClassRoom 관련 엔티티에 케스케이드 설정

---

## 📑 개요
ClassRoom 도메인에 포함된 주요 엔티티(ClassRoomUser, Directory, Document, Assignment)에 대해 Cascade 옵션을 적용하여 연관 데이터 관리가 원활하도록 개선했습니다.
---

## ✅ 작업 내용
- [x] ClassRoomUser, Directory, Document, Assignment 엔티티에 Cascade 설정 추가
- [x] 연관 관계 삭제/저장 시 일관된 동작을 보장하도록 개선
---

## 🔗 관련 이슈
Close #153 

---

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트를 완료했나요?
