### PR TITLE
공지사항 가져오는 api에서 권한 인증하는 로직 삭제

### DIFF
--- a/src/main/java/hello/cluebackend/domain/notice/service/NoticeQueryService.java
+++ b/src/main/java/hello/cluebackend/domain/notice/service/NoticeQueryService.java
@@ -38,9 +38,6 @@ public class NoticeQueryService {
     }
 
     public NoticeInfoDto findById(UUID userId, UUID noticeId) {
-        if(!isMyNotice(userId, noticeId)) {
-            throw new IsNotMyNoticeException("해당 공지사항을 수정할 권한이 없습니다.");
-        }
         Notice notice = noticeJpaRepository.findById(noticeId).orElseThrow(() -> new EntityNotFoundException("해당 공지사항이 찾을 수가 없습니다."));
         List<NoticeDocument> noticeDocument = notice.getNoticeDocuments();
         NoticeInfoDto noticeInfoDto = notice.toInfoDto();


### PR DESCRIPTION
# [#160] 공지사항 세부정부 안 가져와지는 오류 해결

---

## 📑 개요
공지사항 세부정부가 안 가져와지는 오류를 권한인증 로직을 제거함으로써 오류를 해결했습니다.
---

## ✅ 작업 내용
- [x] 공지사항 세부정부가 안 가져와지는 오류 해결

---

## 🔗 관련 이슈
Close #160

---

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트를 완료했나요?