### PR TITLE
submission 링크 추가 오류 해결

### DIFF
--- a/src/main/java/hello/cluebackend/presentation/api/submission/SubmissionQueryController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/submission/SubmissionQueryController.java
@@ -67,7 +67,7 @@ public class SubmissionQueryController {
   }
 
   // 과제 제출 첨부 링크 추가
-  @PostMapping("/{submisisonId}/link")
+  @PostMapping("/{submissionId}/link")
   public ResponseEntity<?> linkUpload(
           @CurrentUser UUID userId,
           @PathVariable UUID submissionId,


### PR DESCRIPTION
# 📌 [#165] submission 링크 추가 오류 해결

---

## 📑 개요
submission 링크 추가 api에서 path variable 값 불일치가 발생해 일치하도록 변경

---

## ✅ 작업 내용
- [X] submission 링크 추가 api에서 path variable 값 불일치가 발생해 일치하도록 변경
---

## 📌 체크리스트
- [X] 코드 컨벤션을 지켰나요?
- [X] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 테스트를 완료했나요?
