### PR TITLE
feat: 과제 첨부 파일 목록 조회 API 추가

### DIFF
--- a/src/main/java/hello/cluebackend/domain/assignment/service/AssignmentCommandService.java
+++ b/src/main/java/hello/cluebackend/domain/assignment/service/AssignmentCommandService.java
@@ -1,5 +1,6 @@
 package hello.cluebackend.domain.assignment.service;
 
+import hello.cluebackend.application.assignment.dto.response.AssignmentAttachmentDto;
 import hello.cluebackend.application.assignment.dto.response.AssignmentDto;
 import hello.cluebackend.application.assignment.dto.response.GetAllAssignmentDto;
 import hello.cluebackend.application.classroom.mapper.ClassRoomMapper;
@@ -82,5 +83,14 @@ public class AssignmentCommandService {
   public Resource downloadAttachment(AssignmentAttachment assignmentAttachment) throws IOException {
     String path = assignmentAttachment.getValue();
     return fileService.downloadFile(path);
+  }
+
+  // 과제 첨부 파일 목록 조회
+  public List<AssignmentAttachmentDto> findAttachmentsByAssignmentId(UUID assignmentId) {
+    Assignment assignment = findByIdOrThrow(assignmentId);
+    List<AssignmentAttachment> attachments = assignmentAttachmentJpaRepository.findAllByAssignment(assignment);
+    return attachments.stream()
+            .map(AssignmentAttachmentDto::from)
+            .toList();
   }
 }

--- a/src/main/java/hello/cluebackend/presentation/api/assignment/AssignmentCommandController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/assignment/AssignmentCommandController.java
@@ -21,6 +21,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import hello.cluebackend.application.assignment.dto.response.AssignmentAttachmentDto;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -68,6 +70,21 @@ public class AssignmentCommandController {
   }
 
   // ------------------------------------------ 첨부 파일 ------------------------------------------ //
+
+  // 첨부 파일 목록 조회
+  @GetMapping("/{assignmentId}/attachment")
+  public ResponseEntity<List<AssignmentAttachmentDto>> getAttachments(
+          @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+          @PathVariable UUID assignmentId
+  ) {
+    Assignment assignment = assignmentCommandService.findByIdOrThrow(assignmentId);
+    UUID classroomId = assignment.getClassRoom().getClassRoomId();
+    if (!classroomUserService.isUserInClassroom(classroomId, customOAuth2User.getUserId())) {
+      throw new AccessDeniedException("해당 수업실에 속하지 않은 유저입니다.");
+    }
+    List<AssignmentAttachmentDto> attachments = assignmentCommandService.findAttachmentsByAssignmentId(assignmentId);
+    return ResponseEntity.ok(attachments);
+  }
 
   // 첨부 파일 다운로드
   @GetMapping("/{assignmentAttachmentId}/download")


### PR DESCRIPTION
- GET /api/assignments/{assignmentId}/attachment 엔드포인트 추가
- 학생이 과제의 첨부 파일 목록을 조회하여 assignmentAttachmentId를 받을 수 있도록 함
- assignmentAttachmentId를 통해 /api/assignments/{assignmentAttachmentId}/download 로 파일 다운로드 가능