### PR TITLE
submission 선생님 조회 권한 추가

### DIFF
--- a/src/main/java/hello/cluebackend/domain/submission/service/SubmissionCommandService.java
+++ b/src/main/java/hello/cluebackend/domain/submission/service/SubmissionCommandService.java
@@ -59,8 +59,9 @@ public class SubmissionCommandService {
   // 과제 제출 단일 조회
   public SubmissionResponse findByAssignmentId(UUID userId, UUID submissionId) {
     Submission submission = findByIdOrThrow(submissionId);
+    UserEntity requestUser = userService.findById(userId);
 
-    if (!submission.getUser().getUserId().equals(userId) || !submission.getUser().getRole().equals(Role.TEACHER)) {
+    if (!submission.getUser().getUserId().equals(userId) && !requestUser.getRole().equals(Role.TEACHER)) {
       throw new AccessDeniedException("사용자가 제출한 과제가 아닙니다.");
     }
 

--- a/src/main/java/hello/cluebackend/domain/submission/service/SubmissionCommandService.java
+++ b/src/main/java/hello/cluebackend/domain/submission/service/SubmissionCommandService.java
@@ -74,6 +74,11 @@ public class SubmissionCommandService {
 
   // 전체 학생 과제 제출 여부 (선생)
   public List<SubmissionCheck> checkAssignment(UUID userId, UUID assignmentId) {
+    UserEntity requestUser = userService.findById(userId);
+    if (!requestUser.getRole().equals(Role.TEACHER)) {
+      throw new AccessDeniedException("선생님만 조회할 수 있습니다.");
+    }
+
     Assignment assignment = assignmentCommandService.findByIdOrThrow(assignmentId);
     List<Submission> submissions = submissionJpaRepository.findAllByAssignment(assignment);
     return submissions.stream()
@@ -85,6 +90,12 @@ public class SubmissionCommandService {
   // 첨부 파일 혹은 링크 전체 조회 (학생)
   public List<SubmissionAttachmentResponse> findAllAssignmentStudent(UUID userId, UUID submissionId) {
     Submission submission = findByIdOrThrow(submissionId);
+    UserEntity requestUser = userService.findById(userId);
+
+    if (!submission.getUser().getUserId().equals(userId) && !requestUser.getRole().equals(Role.TEACHER)) {
+      throw new AccessDeniedException("사용자가 제출한 과제가 아닙니다.");
+    }
+
     List<SubmissionAttachment> attachments = submissionAttachmentJpaRepository.findAllBySubmission(submission);
     return attachments.stream()
             .filter(sa -> sa.getUser().getUserId().equals(userId))
@@ -93,7 +104,12 @@ public class SubmissionCommandService {
   }
 
   // 첨부 파일 혹은 링크 전체 조회 (선생)
-  public List<SubmissionAttachmentResponse> findAllAssignmentTeacher(UUID submissionId) {
+  public List<SubmissionAttachmentResponse> findAllAssignmentTeacher(UUID userId, UUID submissionId) {
+    UserEntity requestUser = userService.findById(userId);
+    if (!requestUser.getRole().equals(Role.TEACHER)) {
+      throw new AccessDeniedException("선생님만 조회할 수 있습니다.");
+    }
+
     Submission submission = findByIdOrThrow(submissionId);
     List<SubmissionAttachment> attachments = submissionAttachmentJpaRepository.findAllBySubmission(submission);
     return attachments.stream()

--- a/src/main/java/hello/cluebackend/domain/submission/service/SubmissionCommandService.java
+++ b/src/main/java/hello/cluebackend/domain/submission/service/SubmissionCommandService.java
@@ -60,7 +60,7 @@ public class SubmissionCommandService {
   public SubmissionResponse findByAssignmentId(UUID userId, UUID submissionId) {
     Submission submission = findByIdOrThrow(submissionId);
 
-    if (!submission.getUser().getUserId().equals(userId) && !submission.getUser().getRole().equals(Role.TEACHER)) {
+    if (!submission.getUser().getUserId().equals(userId) || !submission.getUser().getRole().equals(Role.TEACHER)) {
       throw new AccessDeniedException("사용자가 제출한 과제가 아닙니다.");
     }
 

--- a/src/main/java/hello/cluebackend/domain/submission/service/SubmissionQueryService.java
+++ b/src/main/java/hello/cluebackend/domain/submission/service/SubmissionQueryService.java
@@ -12,6 +12,7 @@ import hello.cluebackend.domain.classroom.model.ClassRoom;
 import hello.cluebackend.domain.classroom.service.ClassRoomQueryService;
 import hello.cluebackend.domain.classroomuser.service.ClassroomUserService;
 import hello.cluebackend.infrastructure.persistence.submissionattachment.SubmissionAttachmentJpaRepository;
+import hello.cluebackend.domain.user.model.Role;
 import hello.cluebackend.domain.user.model.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,7 @@ public class SubmissionQueryService {
     ClassRoom classRoom = classRoomMapper.fromClassRoomDtoToEntity(classRoomQueryService.findById(userId ,classroomId));
     List<UserEntity> users = classroomUserService.findAllClassroomUser(classRoom);
     List<Submission> submissions = users.stream()
+            .filter(u -> !u.getRole().equals(Role.TEACHER))
             .map(u -> new Submission(assignment, u,assignment.getClassRoom(), false, null))
             .toList();
     submissionJpaRepository.saveAll(submissions);


### PR DESCRIPTION
# 📌 PR 제목 규칙
[FIX] submission 선생님 조회 권한 수정

---

## 📑 개요
submission API들에서 선생님 권한 추가


---

## ✅ 작업 내용
- [x] `GET /api/submissions/assignment/{submissionId}` Teacher 권한 조회 가능
- [x] `GET /api/submissions/{assignmentId}/check` Teacher만 사용 가능하도록 수정


## 테스트 체크 리스트
 - 학생이 본인의 submission 조회 가능 확인
 - 학생이 타인의 submission 조회 시 접근 거부 확인
 - 선생님이 모든 학생의 submission 조회 가능 확인
 - 과제 생성 시 선생님에게 submission이 할당되지 않는지 확인

---

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 테스트를 완료했나요?