### PR TITLE
링크 수정/삭제 권한 문제가 발생하면 403 반환

### DIFF
--- a/src/main/java/hello/cluebackend/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/hello/cluebackend/common/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package hello.cluebackend.common.handler;
 
+import feign.FeignException;
 import hello.cluebackend.common.ErrorResponse;
 import hello.cluebackend.domain.assignment.exception.AccessDeniedException;
 import hello.cluebackend.domain.file.exception.S3FileNotFoundException;
@@ -77,6 +78,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleWebClientResponseException(WebClientResponseException ex) {
         ErrorResponse errorResponse = new ErrorResponse("WEBCLIENT_RESPONSE_ERROR", ex.getMessage());
         return new ResponseEntity<>(errorResponse, ex.getStatusCode());
+    }
+
+    @ExceptionHandler(FeignException.class)
+    public ResponseEntity<ErrorResponse> handleFeignException(FeignException ex) {
+        int status = ex.status();
+        String message = ex.getMessage();
+
+        if (status >= 400 && status < 500) {
+            ErrorResponse errorResponse = new ErrorResponse("FEIGN_CLIENT_ERROR", message);
+            return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(status));
+        }
+
+        ErrorResponse errorResponse = new ErrorResponse("FEIGN_SERVER_ERROR", message);
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/hello/cluebackend/domain/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/hello/cluebackend/domain/user/service/CustomOAuth2UserService.java
@@ -30,9 +30,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String email = oAuth2User.getAttribute("email");
         String isTeacher = email.split("@")[0];
-
+//        String isBssm = email.split("@")[1];
         Role role;
-        if(isTeacher.equals("teacher")) role = Role.TEACHER;
+
+//        if(isTeacher.startsWith("teacher") && isBssm.equals("bssm.hs.kr")) role = Role.TEACHER;
+        if(isTeacher.startsWith("teacher")) role = Role.TEACHER;
         else role = Role.STUDENT;
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();


### PR DESCRIPTION
# [#182 ] 링크 수정/삭제 권한 오류 시 403 상태 코드 반환

  ---

  ## 📑 개요
  링크 수정/삭제 시 권한 문제가 발생할 때 Feign Client의 에러를 적절히 처리하여 403 상태 코드를 반환하도록 개선했습니다.

  ---

  ## ✅ 작업 내용
  - [x] GlobalExceptionHandler에 FeignException 핸들러 추가
  - [x] 4xx 클라이언트 에러와 5xx 서버 에러 구분 처리
  - [x] Feign 호출 시 발생하는 원본 HTTP 상태 코드 유지

  ---

  ## 🔗 관련 이슈
  Close #182

  ---

  ## 📌 체크리스트
  - [x] 코드 컨벤션을 지켰나요?
  - [x] 커밋 메시지 컨벤션을 지켰나요?
  - [x] 테스트를 완료했나요?
