### PR TITLE
링크 소유자 확인 필드 추가

### DIFF
--- a/src/main/java/hello/cluebackend/application/linksave/dto/response/LinkResponse.java
+++ b/src/main/java/hello/cluebackend/application/linksave/dto/response/LinkResponse.java
@@ -20,4 +20,5 @@ public class LinkResponse {
     private String link;
     private AuthorizationType authorizationType;
     private SubjectType subjectType;
+    private boolean isMine;
 }


### PR DESCRIPTION
 # [#188] 링크 소유자 확인 필드 추가

  ---

  ## 📑 개요
  LinkResponse에 `isMine` 필드를 추가하여 클라이언트에서 해당 링크가 현재 사용자의 것인지 확인할 수 있도록 개선했습니다.

  ---

  ## ✅ 작업 내용
  - [x] LinkResponse에 `isMine` boolean 필드 추가
  - [x] 링크 소유자 확인 기능 구현

  ---

  ## 🔗 관련 이슈
  Close #188

  ---

  ## 📌 체크리스트
  - [x] 코드 컨벤션을 지켰나요?
  - [x] 커밋 메시지 컨벤션을 지켰나요?
  - [x] 테스트를 완료했나요?
