### PR TITLE
Rqb 2 과제 제출 자료 다운로드 안됨 오류 수정

### DIFF
--- a/src/main/java/hello/cluebackend/presentation/api/submission/SubmissionCommandController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/submission/SubmissionCommandController.java
@@ -74,7 +74,6 @@ public class SubmissionCommandController {
 
     return ResponseEntity.ok()
             .contentType(mediaType)
-//            .contentLength(resource.contentLength())
             .header(HttpHeaders.CONTENT_DISPOSITION, ContentDisposition.attachment()
                     .filename(original, StandardCharsets.UTF_8)
                     .build()

--- a/src/main/java/hello/cluebackend/presentation/api/submission/SubmissionCommandController.java
+++ b/src/main/java/hello/cluebackend/presentation/api/submission/SubmissionCommandController.java
@@ -74,7 +74,7 @@ public class SubmissionCommandController {
 
     return ResponseEntity.ok()
             .contentType(mediaType)
-            .contentLength(resource.contentLength())
+//            .contentLength(resource.contentLength())
             .header(HttpHeaders.CONTENT_DISPOSITION, ContentDisposition.attachment()
                     .filename(original, StandardCharsets.UTF_8)
                     .build()


### PR DESCRIPTION
# 과제 제출 자료 다운로드 오류 수정

---

## 📑 개요
제출한 과제 자료를 다운로드할 때 contentLength() 메서드 호출로 인해 발생하는 오류를 수정했습니다.


---

## ✅ 작업 내용
- [x] SubmissionCommandController에서 파일 다운로드 시 contentLength() 메서드 호출 제거

- [x] ResponseEntity 빌더에서 contentLength 설정 제거

---

## 📌 체크리스트
- [x] 코드 컨벤션을 지켰나요?

- [x] 커밋 메시지 컨벤션을 지켰나요?

- [x] 테스트를 완료했나요?