### PR TITLE
Rqb 7 퀴즈 기능 오류 수정

### DIFF
--- a/src/main/java/hello/cluebackend/domain/quizbattle/service/QuizBattleService.java
+++ b/src/main/java/hello/cluebackend/domain/quizbattle/service/QuizBattleService.java
@@ -85,7 +85,10 @@ public class QuizBattleService {
             finalQuestionCount, questions.size(), roomCode);
     }
 
-    log.info("Created room {} with {} questions", roomCode, questions.size());
+    // 호스트 정보를 레디스에 저장 (권한 확인용, 참가자 목록과 별도)
+    redisService.setHost(roomCode, hostId, null);
+    log.info("Created room {} with {} questions, host {} set",
+        roomCode, questions.size(), host.getUsername());
 
     return savedRoom;
   }
@@ -306,6 +309,47 @@ public class QuizBattleService {
                 log.info("User {} left room {} (disconnected session: {})", userId, roomCode, sessionId);
             }
         }
+    }
+
+    public DisconnectResult handleDisconnect(String sessionId) {
+        String roomCode = redisService.getRoomCodeBySessionId(sessionId);
+        if (roomCode == null) {
+            log.debug("No room found for disconnected session: {}", sessionId);
+            return null;
+        }
+
+        UUID userId = redisService.getUserIdBySessionId(roomCode, sessionId);
+        if (userId == null) {
+            log.debug("No user found for disconnected session: {}", sessionId);
+            return null;
+        }
+
+        QuizRoom room = quizRoomRepository.findByRoomCode(roomCode).orElse(null);
+        if (room == null) {
+            log.debug("Room {} not found in database for disconnected session: {}", roomCode, sessionId);
+            return null;
+        }
+
+        boolean wasHost = room.isHost(userId);
+
+        redisService.removeParticipant(roomCode, userId);
+        redisService.removeSessionMapping(sessionId);
+
+        log.info("User {} disconnected from room {} (host: {})", userId, roomCode, wasHost);
+
+        return DisconnectResult.builder()
+                .roomCode(roomCode)
+                .userId(userId)
+                .wasHost(wasHost)
+                .build();
+    }
+
+    @lombok.Builder
+    @lombok.Getter
+    public static class DisconnectResult {
+        private String roomCode;
+        private UUID userId;
+        private boolean wasHost;
     }
 
     public QuizRoom getRoom(String roomCode) {

--- a/src/main/java/hello/cluebackend/domain/quizbattle/service/QuizRoomRedisService.java
+++ b/src/main/java/hello/cluebackend/domain/quizbattle/service/QuizRoomRedisService.java
@@ -19,6 +19,8 @@ public class QuizRoomRedisService {
 
     private static final String PARTICIPANT_KEY_PREFIX = "quiz:room:";
     private static final String PARTICIPANT_KEY_SUFFIX = ":participants";
+    private static final String HOST_KEY_PREFIX = "quiz:room:";
+    private static final String HOST_KEY_SUFFIX = ":host";
     private static final String QUESTION_KEY_PREFIX = "quiz:room:";
     private static final String QUESTION_KEY_SUFFIX = ":questions";
     private static final String ANSWER_KEY_PREFIX = "quiz:room:";
@@ -91,6 +93,73 @@ public class QuizRoomRedisService {
         String key = getParticipantKey(roomCode);
         redisTemplate.delete(key);
         log.info("Cleared all participants from room {}", roomCode);
+    }
+
+    public void setHost(String roomCode, UUID hostId, String sessionId) {
+        String key = getHostKey(roomCode);
+        Map<String, Object> hostInfo = new HashMap<>();
+        hostInfo.put("hostId", hostId.toString());
+        hostInfo.put("sessionId", sessionId);
+
+        redisTemplate.opsForHash().putAll(key, hostInfo);
+        redisTemplate.expire(key, DEFAULT_EXPIRATION_HOURS, TimeUnit.HOURS);
+
+        if (sessionId != null) {
+            addSessionMapping(sessionId, roomCode);
+        }
+
+        log.info("Set host {} for room {}", hostId, roomCode);
+    }
+
+    public UUID getHostId(String roomCode) {
+        String key = getHostKey(roomCode);
+        Object hostIdObj = redisTemplate.opsForHash().get(key, "hostId");
+        return hostIdObj != null ? UUID.fromString((String) hostIdObj) : null;
+    }
+
+    public String getHostSessionId(String roomCode) {
+        String key = getHostKey(roomCode);
+        Object sessionIdObj = redisTemplate.opsForHash().get(key, "sessionId");
+        return sessionIdObj != null ? (String) sessionIdObj : null;
+    }
+
+    public boolean isHost(String roomCode, UUID userId) {
+        UUID hostId = getHostId(roomCode);
+        return hostId != null && hostId.equals(userId);
+    }
+
+    public void updateHostSessionId(String roomCode, String sessionId) {
+        String key = getHostKey(roomCode);
+        String oldSessionId = getHostSessionId(roomCode);
+
+        // 기존 세션 매핑 제거
+        if (oldSessionId != null) {
+            removeSessionMapping(oldSessionId);
+        }
+
+        // 새 세션 ID 저장
+        redisTemplate.opsForHash().put(key, "sessionId", sessionId);
+        redisTemplate.expire(key, DEFAULT_EXPIRATION_HOURS, TimeUnit.HOURS);
+
+        // 세션 매핑 추가
+        if (sessionId != null) {
+            addSessionMapping(sessionId, roomCode);
+        }
+
+        log.info("Updated host session ID for room {}", roomCode);
+    }
+
+    public void clearHost(String roomCode) {
+        String key = getHostKey(roomCode);
+        String sessionId = getHostSessionId(roomCode);
+
+        redisTemplate.delete(key);
+
+        if (sessionId != null) {
+            removeSessionMapping(sessionId);
+        }
+
+        log.info("Cleared host for room {}", roomCode);
     }
 
     public void storeQuestions(String roomCode, List<QuizQuestion> questions) {
@@ -195,6 +264,7 @@ public class QuizRoomRedisService {
 
     public void clearRoomData(String roomCode) {
         clearParticipants(roomCode);
+        clearHost(roomCode);
         clearQuestions(roomCode);
         String currentQuestionKey = getCurrentQuestionKey(roomCode);
         redisTemplate.delete(currentQuestionKey);
@@ -203,6 +273,10 @@ public class QuizRoomRedisService {
 
     private String getParticipantKey(String roomCode) {
         return PARTICIPANT_KEY_PREFIX + roomCode + PARTICIPANT_KEY_SUFFIX;
+    }
+
+    private String getHostKey(String roomCode) {
+        return HOST_KEY_PREFIX + roomCode + HOST_KEY_SUFFIX;
     }
 
     private String getQuestionKey(String roomCode) {

--- a/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/QuizBattleWebSocketController.java
+++ b/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/QuizBattleWebSocketController.java
@@ -354,20 +354,43 @@ public class QuizBattleWebSocketController {
     ) {
         try {
             UUID userId = getUserIdFromHeader(headerAccessor);
+
+            // 먼저 호스트 여부 확인
+            QuizRoom room = quizBattleService.getRoom(roomCode);
+            boolean wasHost = room.isHost(userId);
+
+            // 방을 떠남
             quizBattleService.leaveRoom(roomCode, userId);
 
-            List<QuizParticipant> remainingParticipants = quizBattleService.getParticipants(roomCode);
+            // 호스트가 나갔으면 방 전체를 취소
+            if (wasHost) {
+                quizTimerService.cancelAllTimersForRoom(roomCode);
+                quizBattleService.cancelRoom(roomCode);
 
-            ParticipantLeftMessage message = ParticipantLeftMessage.builder()
-                    .userId(userId)
-                    .totalParticipants(remainingParticipants.size())
-                    .allParticipants(remainingParticipants)
-                    .status("success")
-                    .build();
+                RoomCancelledMessage message = RoomCancelledMessage.builder()
+                        .roomCode(roomCode)
+                        .reason("host_left")
+                        .status("cancelled")
+                        .message("Room has been cancelled because the host left")
+                        .build();
 
-            messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/participants", message);
+                messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/game", message);
+                log.info("Room {} cancelled because host {} left", roomCode, userId);
+            } else {
+                // 일반 참가자가 나간 경우
+                List<QuizParticipant> remainingParticipants = quizBattleService.getParticipants(roomCode);
 
-            log.info("User {} left room {}", userId, roomCode);
+                ParticipantLeftMessage message = ParticipantLeftMessage.builder()
+                        .userId(userId)
+                        .totalParticipants(remainingParticipants.size())
+                        .allParticipants(remainingParticipants)
+                        .status("success")
+                        .isHostRemaining(true)
+                        .build();
+
+                messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/participants", message);
+                log.info("User {} left room {}", userId, roomCode);
+            }
 
         } catch (Exception e) {
             log.error("Error leaving room", e);
@@ -431,9 +454,26 @@ public class QuizBattleWebSocketController {
                 question.getTimeLimit(),
                 () -> {
                     try {
-                        moveToNextQuestion(roomCode);
+                        // 시간이 끝나면 정답만 공개하고, 다음 문제로는 넘어가지 않음
+                        Integer currentQuestionNum = quizBattleService.getCurrentQuestionNumber(roomCode);
+                        if (currentQuestionNum != null) {
+                            Map<String, Object> result = quizBattleService.revealAnswer(roomCode, currentQuestionNum);
+
+                            AnswerRevealMessage message = AnswerRevealMessage.builder()
+                                    .questionNumber(currentQuestionNum)
+                                    .correctAnswer((Integer) result.get("correctAnswer"))
+                                    .explanation((String) result.get("explanation"))
+                                    .statistics((Map<Integer, Integer>) result.get("statistics"))
+                                    .totalAnswers((Integer) result.get("totalAnswers"))
+                                    .status("success")
+                                    .message("Time's up! Answer revealed")
+                                    .build();
+
+                            messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/game", message);
+                            log.info("Time's up for question {} in room {}, answer revealed", currentQuestionNum, roomCode);
+                        }
                     } catch (Exception e) {
-                        log.error("Error auto-moving to next question in room {}", roomCode, e);
+                        log.error("Error revealing answer after timeout in room {}", roomCode, e);
                     }
                 }
         );

--- a/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/QuizBattleWebSocketController.java
+++ b/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/QuizBattleWebSocketController.java
@@ -7,13 +7,16 @@ import hello.cluebackend.domain.quizbattle.service.QuizTimerService;
 import hello.cluebackend.presentation.websocket.quizbattle.dto.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import java.util.List;
 import java.util.Map;
@@ -29,6 +32,7 @@ public class QuizBattleWebSocketController {
     private final QuizTimerService quizTimerService;
     private final SimpMessagingTemplate messagingTemplate;
     private final JWTUtil jwtUtil;
+    private final hello.cluebackend.domain.quizbattle.service.QuizRoomRedisService redisService;
 
     private UUID getUserIdFromHeader(SimpMessageHeaderAccessor headerAccessor) {
         try {
@@ -80,6 +84,8 @@ public class QuizBattleWebSocketController {
     ) {
         try {
             UUID userId = getUserIdFromHeader(headerAccessor);
+            String sessionId = headerAccessor.getSessionId();
+
             QuizRoom room = quizBattleService.createRoom(
                     userId,
                     request.getMaxParticipants(),
@@ -89,7 +95,10 @@ public class QuizBattleWebSocketController {
                     request.getDocumentId()
             );
 
-            log.info("Room created: {} by user {}", room.getRoomCode(), userId);
+            // 호스트의 WebSocket 세션 ID를 레디스에 업데이트
+            redisService.updateHostSessionId(room.getRoomCode(), sessionId);
+
+            log.info("Room created: {} by user {} with session {}", room.getRoomCode(), userId, sessionId);
 
             return RoomCreatedMessage.builder()
                     .roomCode(room.getRoomCode())
@@ -171,16 +180,28 @@ public class QuizBattleWebSocketController {
 
             // Schedule the first question to be sent after a delay
             quizTimerService.scheduleTask(() -> {
-                List<QuizQuestion> questions = quizBattleService.startQuiz(roomCode);
-                if (questions != null && !questions.isEmpty()) {
-                    QuizQuestion firstQuestion = questions.get(0);
-                    sendQuestionToRoom(roomCode, firstQuestion);
-                    log.info("Quiz started in room {} and first question sent", roomCode);
-                } else {
-                    log.error("No questions found for room {} after starting quiz.", roomCode);
-                     ErrorMessage error = ErrorMessage.builder()
+                try {
+                    List<QuizQuestion> questions = quizBattleService.startQuiz(roomCode);
+                    if (questions != null && !questions.isEmpty()) {
+                        QuizQuestion firstQuestion = questions.get(0);
+                        sendQuestionToRoom(roomCode, firstQuestion);
+                        log.info("Quiz started in room {} and first question sent", roomCode);
+                    } else {
+                        log.error("No questions found for room {} after starting quiz.", roomCode);
+                         ErrorMessage error = ErrorMessage.builder()
+                            .status("error")
+                            .message("Failed to start quiz: No questions were found.")
+                            .build();
+                        messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/game", error);
+                    }
+                } catch (IllegalStateException e) {
+                    // 이미 시작되었거나 종료된 경우 무시
+                    log.warn("Quiz already started or finished for room {}: {}", roomCode, e.getMessage());
+                } catch (Exception e) {
+                    log.error("Error starting quiz for room {}", roomCode, e);
+                    ErrorMessage error = ErrorMessage.builder()
                         .status("error")
-                        .message("Failed to start quiz: No questions were found.")
+                        .message("Failed to start quiz: " + e.getMessage())
                         .build();
                     messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/game", error);
                 }
@@ -375,7 +396,7 @@ public class QuizBattleWebSocketController {
                         .build();
 
                 messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/game", message);
-                log.info("Room {} cancelled because host {} left", roomCode, userId);
+                log.info("##### Room {} cancelled because host {} left #####", roomCode, userId);
             } else {
                 // 일반 참가자가 나간 경우
                 List<QuizParticipant> remainingParticipants = quizBattleService.getParticipants(roomCode);

--- a/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/WebSocketEventListener.java
+++ b/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/WebSocketEventListener.java
@@ -26,6 +26,8 @@ public class WebSocketEventListener {
 
   @EventListener
   public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+    System.out.println("###################### FUCK DISCONNECT #################");
+
     StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
     String sessionId = headerAccessor.getSessionId();
 
@@ -34,25 +36,59 @@ public class WebSocketEventListener {
     if (sessionId != null) {
       try {
         String roomCode = redisService.getRoomCodeBySessionId(sessionId);
-
+        System.out.println("####### room code: " + roomCode);
         if (roomCode != null) {
-          java.util.UUID userId = redisService.getUserIdBySessionId(roomCode, sessionId);
+          // 먼저 호스트인지 확인
+          String hostSessionId = redisService.getHostSessionId(roomCode);
+          boolean isHost = sessionId.equals(hostSessionId);
 
-          if (userId != null) {
-            quizBattleService.leaveRoomBySessionId(sessionId);
+          if (isHost) {
+            // 호스트가 연결 끊김
+            java.util.UUID hostId = redisService.getHostId(roomCode);
+            System.out.println("####### HOST disconnected, host id: " + hostId);
 
-            List<QuizParticipant> remainingParticipants = quizBattleService.getParticipants(roomCode);
+            // 타이머 취소
+            quizTimerService.cancelAllTimersForRoom(roomCode);
 
-            ParticipantLeftMessage message = ParticipantLeftMessage.builder()
-                    .userId(userId)
-                    .totalParticipants(remainingParticipants.size())
-                    .allParticipants(remainingParticipants)
-                    .status("success")
+            // 방 취소
+            quizBattleService.cancelRoom(roomCode);
+
+            // 모든 참가자에게 방이 취소되었음을 알림
+            hello.cluebackend.presentation.websocket.quizbattle.dto.RoomCancelledMessage message =
+                hello.cluebackend.presentation.websocket.quizbattle.dto.RoomCancelledMessage.builder()
+                    .roomCode(roomCode)
+                    .reason("host_disconnected")
+                    .status("cancelled")
+                    .message("Room has been cancelled because the host disconnected")
                     .build();
 
-            messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/participants", message);
+            messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/game", message);
 
-            log.info("User {} automatically left room {} due to disconnection", userId, roomCode);
+            log.warn("Host {} disconnected from room {}, room cancelled and all participants removed", hostId, roomCode);
+
+          } else {
+            // 학생(참가자)이 연결 끊김
+            java.util.UUID userId = redisService.getUserIdBySessionId(roomCode, sessionId);
+            System.out.println("####### STUDENT disconnected, user id: " + userId);
+
+            if (userId != null) {
+              System.out.println("############################# SUCCESS #############################");
+              quizBattleService.leaveRoomBySessionId(sessionId);
+
+              List<QuizParticipant> remainingParticipants = quizBattleService.getParticipants(roomCode);
+
+              ParticipantLeftMessage message = ParticipantLeftMessage.builder()
+                      .userId(userId)
+                      .totalParticipants(remainingParticipants.size())
+                      .allParticipants(remainingParticipants)
+                      .status("success")
+                      .build();
+
+              messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/participants", message);
+
+              log.info("Student {} automatically left room {} due to disconnection", userId, roomCode);
+              System.out.println("===========================================================");
+            }
           }
         }
       } catch (Exception e) {

--- a/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/dto/ParticipantLeftMessage.java
+++ b/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/dto/ParticipantLeftMessage.java
@@ -16,4 +16,5 @@ public class ParticipantLeftMessage {
     private Integer totalParticipants;
     private List<QuizParticipant> allParticipants;
     private String status;
+    private Boolean isHostRemaining;
 }


### PR DESCRIPTION
 # [RQB-7] 퀴즈 기능 오류 수정

  ---

  ## 📑 개요
  퀴즈 배틀 기능의 호스트 연결 종료 시 방 처리 및 시간 종료 시 정답 확인 로직 개선

  ---

  ## ✅ 작업 내용
  - [x] 호스트 연결 종료 시 모든 참가자 연결 끊김 및 방 취소 기능 구현
  - [x] 퀴즈 시간 종료 시 자동으로 정답 확인 가능하도록 수정
  - [x] 호스트 정보를 Redis에 저장하여 호스트 권한 확인 로직 추가
  - [x] 호스트가 방을 떠날 때 방 전체 취소 처리
  - [x] WebSocket 연결 해제 이벤트 리스너에서 호스트/학생 구분 처리

  ---

  ## 📌 체크리스트
  - [ ] 코드 컨벤션을 지켰나요?
  - [ ] 커밋 메시지 컨벤션을 지켰나요?
  - [ ] 테스트를 완료했나요?


[RQB-7]: https://haeyul.atlassian.net/browse/RQB-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ