### PR TITLE
RQB7 - 답변한 학생 수 반환

### DIFF
--- a/src/main/java/hello/cluebackend/application/quizbattle/dto/RevealAnswerResponse.java
+++ b/src/main/java/hello/cluebackend/application/quizbattle/dto/RevealAnswerResponse.java
@@ -1,0 +1,15 @@
+package hello.cluebackend.application.quizbattle.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class RevealAnswerResponse {
+    private final int correctAnswer;
+    private final String explanation;
+    private final Map<Integer, Integer> statistics;
+    private final int totalAnswers;
+}

--- a/src/main/java/hello/cluebackend/application/quizbattle/dto/SubmitAnswerResponse.java
+++ b/src/main/java/hello/cluebackend/application/quizbattle/dto/SubmitAnswerResponse.java
@@ -1,0 +1,12 @@
+package hello.cluebackend.application.quizbattle.dto;
+
+import hello.cluebackend.domain.quizbattle.model.QuizAnswer;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubmitAnswerResponse {
+    private final QuizAnswer answer;
+    private final int totalAnswers;
+}

--- a/src/main/java/hello/cluebackend/domain/quizbattle/model/QuizParticipant.java
+++ b/src/main/java/hello/cluebackend/domain/quizbattle/model/QuizParticipant.java
@@ -20,6 +20,7 @@ public class QuizParticipant implements Serializable {
     private Integer correctAnswers;
     private Boolean isReady;
     private Long joinedAt;
+    private String profileImage;
 
     public void addScore(int points) {
         this.score = (this.score != null ? this.score : 0) + points;

--- a/src/main/java/hello/cluebackend/domain/quizbattle/service/QuizBattleService.java
+++ b/src/main/java/hello/cluebackend/domain/quizbattle/service/QuizBattleService.java
@@ -93,7 +93,7 @@ public class QuizBattleService {
     return savedRoom;
   }
 
-  public QuizParticipant joinRoom(String roomCode, UUID userId, String sessionId) {
+  public QuizParticipant joinRoom(String roomCode, UUID userId, String sessionId, String profileImage) {
     QuizRoom room = quizRoomRepository.findByRoomCode(roomCode)
             .orElseThrow(() -> new IllegalArgumentException("Room not found: " + roomCode));
 
@@ -117,6 +117,7 @@ public class QuizBattleService {
             .correctAnswers(0)
             .isReady(false)
             .joinedAt(System.currentTimeMillis())
+            .profileImage(profileImage)
             .build();
 
     redisService.addParticipant(roomCode, participant);
@@ -205,7 +206,7 @@ public class QuizBattleService {
         }
     }
 
-    public QuizAnswer submitAnswer(
+    public Map<String, Object> submitAnswer(
             String roomCode, UUID userId, int questionNumber,
             int answerIndex, long submittedAt, int timeSpent) {
         QuizRoom room = quizRoomRepository.findByRoomCode(roomCode)
@@ -263,7 +264,15 @@ public class QuizBattleService {
         log.info("User {} submitted answer for question {} in room {}, correct: {}, points: {}",
                 userId, questionNumber, roomCode, isCorrect, answer.getPoints());
 
-        return answer;
+        Map<Integer, Integer> statistics = redisService.getAnswerStatistics(roomCode, questionNumber);
+        int totalAnswers = statistics.values().stream().mapToInt(Integer::intValue).sum();
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("answer", answer);
+        result.put("totalAnswers", totalAnswers);
+
+
+        return result;
     }
 
     public List<QuizRanking> getRankings(String roomCode) {

--- a/src/main/java/hello/cluebackend/domain/quizbattle/service/QuizBattleService.java
+++ b/src/main/java/hello/cluebackend/domain/quizbattle/service/QuizBattleService.java
@@ -1,6 +1,8 @@
 package hello.cluebackend.domain.quizbattle.service;
 
 import hello.cluebackend.application.agent.dto.response.AgentResponse;
+import hello.cluebackend.application.quizbattle.dto.SubmitAnswerResponse;
+import hello.cluebackend.application.quizbattle.dto.RevealAnswerResponse;
 import hello.cluebackend.application.quizbattle.dto.QuizGenerationRequest;
 import hello.cluebackend.application.quizbattle.dto.QuizGenerationResponse;
 import hello.cluebackend.domain.classroom.model.ClassRoom;
@@ -206,7 +208,7 @@ public class QuizBattleService {
         }
     }
 
-    public Map<String, Object> submitAnswer(
+    public SubmitAnswerResponse submitAnswer(
             String roomCode, UUID userId, int questionNumber,
             int answerIndex, long submittedAt, int timeSpent) {
         QuizRoom room = quizRoomRepository.findByRoomCode(roomCode)
@@ -267,12 +269,10 @@ public class QuizBattleService {
         Map<Integer, Integer> statistics = redisService.getAnswerStatistics(roomCode, questionNumber);
         int totalAnswers = statistics.values().stream().mapToInt(Integer::intValue).sum();
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("answer", answer);
-        result.put("totalAnswers", totalAnswers);
-
-
-        return result;
+        return SubmitAnswerResponse.builder()
+                .answer(answer)
+                .totalAnswers(totalAnswers)
+                .build();
     }
 
     public List<QuizRanking> getRankings(String roomCode) {
@@ -387,7 +387,7 @@ public class QuizBattleService {
         log.info("Set question {} to ACTIVE in room {}", questionNumber, roomCode);
     }
 
-    public Map<String, Object> revealAnswer(String roomCode, int questionNumber) {
+    public RevealAnswerResponse revealAnswer(String roomCode, int questionNumber) {
         QuizQuestion question = redisService.getQuestion(roomCode, questionNumber);
         if (question == null) {
             throw new IllegalArgumentException("Question not found: " + questionNumber);
@@ -403,15 +403,14 @@ public class QuizBattleService {
         Map<Integer, Integer> statistics = redisService.getAnswerStatistics(roomCode, questionNumber);
         int totalAnswers = statistics.values().stream().mapToInt(Integer::intValue).sum();
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("correctAnswer", question.getCorrectAnswer());
-        result.put("explanation", question.getExplanation());
-        result.put("statistics", statistics);
-        result.put("totalAnswers", totalAnswers);
-
         log.info("Revealed answer for question {} in room {}", questionNumber, roomCode);
 
-        return result;
+        return RevealAnswerResponse.builder()
+                .correctAnswer(question.getCorrectAnswer())
+                .explanation(question.getExplanation())
+                .statistics(statistics)
+                .totalAnswers(totalAnswers)
+                .build();
     }
 
     public void nextQuestion(String roomCode) {

--- a/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/QuizBattleWebSocketController.java
+++ b/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/QuizBattleWebSocketController.java
@@ -122,13 +122,14 @@ public class QuizBattleWebSocketController {
     @MessageMapping("/quiz/join/{roomCode}")
     public void joinRoom(
             @DestinationVariable String roomCode,
+            @Payload JoinRoomRequest request,
             SimpMessageHeaderAccessor headerAccessor
     ) {
         try {
             UUID userId = getUserIdFromHeader(headerAccessor);
             String sessionId = headerAccessor.getSessionId();
 
-            QuizParticipant participant = quizBattleService.joinRoom(roomCode, userId, sessionId);
+            QuizParticipant participant = quizBattleService.joinRoom(roomCode, userId, sessionId, request.getProfileImage());
             List<QuizParticipant> allParticipants = quizBattleService.getParticipants(roomCode);
 
             ParticipantJoinedMessage message = ParticipantJoinedMessage.builder()
@@ -225,7 +226,7 @@ public class QuizBattleWebSocketController {
     ) {
         try {
             UUID userId = getUserIdFromHeader(headerAccessor);
-            QuizAnswer answer = quizBattleService.submitAnswer(
+            Map<String, Object> resultData = quizBattleService.submitAnswer(
                     roomCode,
                     userId,
                     request.getQuestionNumber(),
@@ -233,6 +234,9 @@ public class QuizBattleWebSocketController {
                     request.getSubmittedAt(),
                     request.getTimeSpent()
             );
+
+            QuizAnswer answer = (QuizAnswer) resultData.get("answer");
+            int totalAnswers = (int) resultData.get("totalAnswers");
 
             AnswerResultMessage result = AnswerResultMessage.builder()
                     .questionNumber(answer.getQuestionNumber())
@@ -247,8 +251,19 @@ public class QuizBattleWebSocketController {
                     result
             );
 
-            log.info("User {} submitted answer for question {} in room {}",
-                    userId, request.getQuestionNumber(), roomCode);
+            // Notify everyone in the room about the new answer count
+            int totalParticipants = quizBattleService.getParticipants(roomCode).size();
+            AnswerCountMessage countMessage = AnswerCountMessage.builder()
+                .status("ANSWER_SUBMITTED")
+                .message("An answer was submitted.")
+                .questionNumber(request.getQuestionNumber())
+                .totalAnswers(totalAnswers)
+                .totalParticipants(totalParticipants)
+                .build();
+            messagingTemplate.convertAndSend("/topic/quiz/" + roomCode + "/game", countMessage);
+
+            log.info("User {} submitted answer for question {} in room {}, total answers now {}",
+                    userId, request.getQuestionNumber(), roomCode, totalAnswers);
 
         } catch (Exception e) {
             log.error("Error submitting answer", e);

--- a/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/QuizBattleWebSocketController.java
+++ b/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/QuizBattleWebSocketController.java
@@ -2,7 +2,9 @@ package hello.cluebackend.presentation.websocket.quizbattle;
 
 import hello.cluebackend.common.utils.JWTUtil;
 import hello.cluebackend.domain.quizbattle.model.*;
+import hello.cluebackend.application.quizbattle.dto.SubmitAnswerResponse;
 import hello.cluebackend.domain.quizbattle.service.QuizBattleService;
+import hello.cluebackend.application.quizbattle.dto.RevealAnswerResponse;
 import hello.cluebackend.domain.quizbattle.service.QuizTimerService;
 import hello.cluebackend.presentation.websocket.quizbattle.dto.*;
 import lombok.RequiredArgsConstructor;
@@ -226,7 +228,7 @@ public class QuizBattleWebSocketController {
     ) {
         try {
             UUID userId = getUserIdFromHeader(headerAccessor);
-            Map<String, Object> resultData = quizBattleService.submitAnswer(
+            SubmitAnswerResponse resultData = quizBattleService.submitAnswer(
                     roomCode,
                     userId,
                     request.getQuestionNumber(),
@@ -235,8 +237,8 @@ public class QuizBattleWebSocketController {
                     request.getTimeSpent()
             );
 
-            QuizAnswer answer = (QuizAnswer) resultData.get("answer");
-            int totalAnswers = (int) resultData.get("totalAnswers");
+            QuizAnswer answer = resultData.getAnswer();
+            int totalAnswers = resultData.getTotalAnswers();
 
             AnswerResultMessage result = AnswerResultMessage.builder()
                     .questionNumber(answer.getQuestionNumber())
@@ -299,14 +301,14 @@ public class QuizBattleWebSocketController {
 
             quizTimerService.cancelQuestionTimer(roomCode, currentQuestionNum);
 
-            Map<String, Object> result = quizBattleService.revealAnswer(roomCode, currentQuestionNum);
+            RevealAnswerResponse result = quizBattleService.revealAnswer(roomCode, currentQuestionNum);
 
             AnswerRevealMessage message = AnswerRevealMessage.builder()
                     .questionNumber(currentQuestionNum)
-                    .correctAnswer((Integer) result.get("correctAnswer"))
-                    .explanation((String) result.get("explanation"))
-                    .statistics((Map<Integer, Integer>) result.get("statistics"))
-                    .totalAnswers((Integer) result.get("totalAnswers"))
+                    .correctAnswer(result.getCorrectAnswer())
+                    .explanation(result.getExplanation())
+                    .statistics(result.getStatistics())
+                    .totalAnswers(result.getTotalAnswers())
                     .status("success")
                     .message("Answer revealed")
                     .build();
@@ -493,14 +495,14 @@ public class QuizBattleWebSocketController {
                         // 시간이 끝나면 정답만 공개하고, 다음 문제로는 넘어가지 않음
                         Integer currentQuestionNum = quizBattleService.getCurrentQuestionNumber(roomCode);
                         if (currentQuestionNum != null) {
-                            Map<String, Object> result = quizBattleService.revealAnswer(roomCode, currentQuestionNum);
+                            RevealAnswerResponse result = quizBattleService.revealAnswer(roomCode, currentQuestionNum);
 
                             AnswerRevealMessage message = AnswerRevealMessage.builder()
                                     .questionNumber(currentQuestionNum)
-                                    .correctAnswer((Integer) result.get("correctAnswer"))
-                                    .explanation((String) result.get("explanation"))
-                                    .statistics((Map<Integer, Integer>) result.get("statistics"))
-                                    .totalAnswers((Integer) result.get("totalAnswers"))
+                                    .correctAnswer(result.getCorrectAnswer())
+                                    .explanation(result.getExplanation())
+                                    .statistics(result.getStatistics())
+                                    .totalAnswers(result.getTotalAnswers())
                                     .status("success")
                                     .message("Time's up! Answer revealed")
                                     .build();

--- a/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/dto/AnswerCountMessage.java
+++ b/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/dto/AnswerCountMessage.java
@@ -1,0 +1,14 @@
+package hello.cluebackend.presentation.websocket.quizbattle.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AnswerCountMessage {
+    private String status;
+    private String message;
+    private int questionNumber;
+    private int totalAnswers;
+    private int totalParticipants;
+}

--- a/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/dto/JoinRoomRequest.java
+++ b/src/main/java/hello/cluebackend/presentation/websocket/quizbattle/dto/JoinRoomRequest.java
@@ -1,0 +1,8 @@
+package hello.cluebackend.presentation.websocket.quizbattle.dto;
+
+import lombok.Data;
+
+@Data
+public class JoinRoomRequest {
+    private String profileImage;
+}


### PR DESCRIPTION
# [#RQB-7] 퀴즈 기능 오류 수정

  ---

  📑 개요
  퀴즈 배틀 기능과 관련된 여러 오류를 수정하여 안정성을 높였습니다. 호스트 연결 문제, 답변 학생 수 집계, 정답 확인 기능 등을 개선했습니다.

  ---

  ✅ 작업 내용
   - [x] 퀴즈 배틀 호스트 연결이 끊어졌을 때, 참여한 학생들의 연결도 함께 종료되도록 수정
   - [x] 시간이 종료된 후에도 정답 확인이 정상적으로 가능하도록 로직 수정
   - [x] 각 문제마다 답변을 제출한 학생 수를 정확히 집계하여 반환하는 기능 추가

 

  ---

  📌 체크리스트
   - [x] 코드 컨벤션을 지켰나요?
   - [ ] 커밋 메시지 컨벤션을 지켰나요?
   - [ ] 테스트를 완료했나요?
